### PR TITLE
tools/zram_setup.sh: fix mount-point dir creation

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -141,11 +141,6 @@ function _rt_require_zram_params {
 			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/out"
 			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/dev"
 		fi
-
-		[ -d "$ZRAM_VSTART_OUT_MNT" ] \
-					|| _fail "missing $ZRAM_VSTART_OUT_MNT"
-		[ -d "$ZRAM_VSTART_DATA_MNT" ] \
-					|| _fail "missing $ZRAM_VSTART_DATA_MNT"
 	fi
 }
 


### PR DESCRIPTION
_rt_require_zram_params shouldn't check for the existence of the mount
point directories, as _zram_setup handles creation if missing. Creation
is needed for Ceph the vstart directories.

Signed-off-by: David Disseldorp <ddiss@suse.de>