### PR TITLE
runtime.vars: expect root repository path for CEPH_SRC

### DIFF
--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -85,12 +85,13 @@ HOSTNAME2="rapido2"
 #############################
 
 ##### Ceph globals #####
-# Path to src directory within Ceph source repository. Only required if a Ceph
-# specific Cut script will be run. vstart.sh should be run prior to Cut.
+# CEPH_SRC should correspond to a checkout and build of the Ceph source
+# available at https://github.com/ceph/ceph. Only required if a Ceph specific
+# Cut script will be run. vstart.sh should be run prior to Cut.
 # If not specified, then the Ceph config, keyring and binaries will be obtained
 # from the local system.
 #
-# e.g. CEPH_SRC="/home/me/ceph/src"
+# e.g. CEPH_SRC="/home/me/ceph"
 CEPH_SRC=""
 
 # user for Ceph authentication. Secret obtained from keyring file.

--- a/runtime.vars
+++ b/runtime.vars
@@ -24,36 +24,56 @@ function _warn() {
 . ${RAPIDO_DIR}/rapido.conf \
 	|| _fail "rapido.conf missing - see rapido.conf.example"
 
+function _rt_ceph_src_munge
+{
+	[ -n "$CEPH_SRC" ] || _fail "CEPH_SRC is unset"
+	[ -d "$CEPH_SRC" ] || _fail "$CEPH_SRC is not a directory"
+
+	# CEPH_SRC used to correspond to the "src" subdirectory of the Ceph
+	# source repository, which was counter intuitive, given that all other
+	# X_SRC rapido.conf parameters correspond to the root of the repository.
+	# Temporarily handle deprecated CEPH_SRC="$ceph_repo/src" configurations
+	# by munging such paths into CEPH_SRC="$ceph_repo/src/../"
+	local ceph_basename="$(basename $CEPH_SRC)"
+	if [ "$ceph_basename" == "src" ] \
+				&& [ -f "${CEPH_SRC}/../ceph.spec.in" ]; then
+		local ceph_src_munged="$(realpath -e ${CEPH_SRC}/../)"
+		_warn "munging CEPH_SRC ($CEPH_SRC) into $ceph_src_munged"
+		_warn "please adjust your rapido.conf"
+		CEPH_SRC="$ceph_src_munged"
+	fi
+}
+
 function _rt_ceph_src_globals_set {
-	if [ -f "${CEPH_SRC}/../build/CMakeCache.txt" ]; then
+	if [ -f "${CEPH_SRC}/build/CMakeCache.txt" ]; then
 		# cmake build, compiled binaries and configs are in build subdir
-		CEPH_BIN="${CEPH_SRC}/../build/bin/ceph"
-		CEPH_RBD_BIN="${CEPH_SRC}/../build/bin/rbd"
-		CEPH_MOUNT_BIN="${CEPH_SRC}/../build/bin/mount.ceph"
-		CEPH_RADOS_BIN="${CEPH_SRC}/../build/bin/rados"
-		CEPH_FUSE_BIN="${CEPH_SRC}/../build/bin/ceph-fuse"
-		CEPH_RADOS_LIB="${CEPH_SRC}/../build/lib/librados.so"
-		CEPH_RBD_LIB="${CEPH_SRC}/../build/lib/librbd.so"
-		CEPH_CONF="${CEPH_SRC}/../build/ceph.conf"
-		CEPH_KEYRING="${CEPH_SRC}/../build/keyring"
+		CEPH_BIN="${CEPH_SRC}/build/bin/ceph"
+		CEPH_RBD_BIN="${CEPH_SRC}/build/bin/rbd"
+		CEPH_MOUNT_BIN="${CEPH_SRC}/build/bin/mount.ceph"
+		CEPH_RADOS_BIN="${CEPH_SRC}/build/bin/rados"
+		CEPH_FUSE_BIN="${CEPH_SRC}/build/bin/ceph-fuse"
+		CEPH_RADOS_LIB="${CEPH_SRC}/build/lib/librados.so"
+		CEPH_RBD_LIB="${CEPH_SRC}/build/lib/librbd.so"
+		CEPH_CONF="${CEPH_SRC}/build/ceph.conf"
+		CEPH_KEYRING="${CEPH_SRC}/build/keyring"
 	else
 		# autotools build
-		CEPH_BIN="${CEPH_SRC}/ceph"
-		CEPH_RBD_BIN="${CEPH_SRC}/rbd"
-		CEPH_MOUNT_BIN="${CEPH_SRC}/mount.ceph"
-		CEPH_RADOS_BIN="${CEPH_SRC}/rados"
-		CEPH_FUSE_BIN="${CEPH_SRC}/ceph-fuse"
-		CEPH_RADOS_LIB="${CEPH_SRC}/.libs/librados.so"
-		CEPH_RBD_LIB="${CEPH_SRC}/.libs/librbd.so"
-		CEPH_CONF="${CEPH_SRC}/ceph.conf"
-		CEPH_KEYRING="${CEPH_SRC}/keyring"
+		CEPH_BIN="${CEPH_SRC}/src/ceph"
+		CEPH_RBD_BIN="${CEPH_SRC}/src/rbd"
+		CEPH_MOUNT_BIN="${CEPH_SRC}/src/mount.ceph"
+		CEPH_RADOS_BIN="${CEPH_SRC}/src/rados"
+		CEPH_FUSE_BIN="${CEPH_SRC}/src/ceph-fuse"
+		CEPH_RADOS_LIB="${CEPH_SRC}/src/.libs/librados.so"
+		CEPH_RBD_LIB="${CEPH_SRC}/src/.libs/librbd.so"
+		CEPH_CONF="${CEPH_SRC}/src/ceph.conf"
+		CEPH_KEYRING="${CEPH_SRC}/src/keyring"
 	fi
 
-	RBD_NAMER_BIN="${CEPH_SRC}/ceph-rbdnamer"
-	RBD_UDEV_RULES="${CEPH_SRC}/../udev/50-rbd.rules"
-	CEPH_UDEV_RULES="${CEPH_SRC}/../udev/95-ceph-osd.rules"
-	CEPH_DISK_SYSTEMD_SVC="${CEPH_SRC}/../systemd/ceph-disk@.service"
-	CEPH_OSD_SYSTEMD_SVC="${CEPH_SRC}/../systemd/ceph-osd@.service"
+	RBD_NAMER_BIN="${CEPH_SRC}/src/ceph-rbdnamer"
+	RBD_UDEV_RULES="${CEPH_SRC}/udev/50-rbd.rules"
+	CEPH_UDEV_RULES="${CEPH_SRC}/udev/95-ceph-osd.rules"
+	CEPH_DISK_SYSTEMD_SVC="${CEPH_SRC}/systemd/ceph-disk@.service"
+	CEPH_OSD_SYSTEMD_SVC="${CEPH_SRC}/systemd/ceph-osd@.service"
 }
 
 function _rt_ceph_installed_globals_set {
@@ -76,6 +96,7 @@ function _rt_ceph_installed_globals_set {
 
 function _rt_require_ceph {
 	if [ -n "$CEPH_SRC" ]; then
+		_rt_ceph_src_munge
 		_rt_ceph_src_globals_set
 	else
 		_rt_ceph_installed_globals_set
@@ -132,14 +153,15 @@ function _rt_require_zram_params {
 	ZRAM_VSTART_DATA_SIZE="1G"
 
 	if [ -n "$CEPH_SRC" ]; then
-		if [ -f "${CEPH_SRC}/../build/CMakeCache.txt" ]; then
+		_rt_ceph_src_munge
+		if [ -f "${CEPH_SRC}/build/CMakeCache.txt" ]; then
 			# with cmake, vstart.sh is triggered from the build dir
-			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/../build/out"
-			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/../build/dev"
+			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/build/out"
+			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/build/dev"
 		else
 			# vstart.sh is triggered from the src dir
-			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/out"
-			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/dev"
+			ZRAM_VSTART_OUT_MNT="${CEPH_SRC}/src/out"
+			ZRAM_VSTART_DATA_MNT="${CEPH_SRC}/src/dev"
 		fi
 	fi
 }


### PR DESCRIPTION
Until now, the CEPH_SRC rapido.conf parameter has required a path to
the "src" subdirectory of the Ceph source repository. This is counter
intuitive, given that all other X_SRC rapido.conf parameters correspond
repository root paths.

Drop the CEPH_SRC "src" subdirectory path requirement, and add temporary
support for translating CEPH_SRC="$ceph_repo/src" configurations into
into CEPH_SRC="$ceph_repo/src/../".

Signed-off-by: David Disseldorp <ddiss@suse.de>