### PR TITLE
cut_fstests_local.sh: Add more missing dependencies

### DIFF
--- a/cut_fstests_local.sh
+++ b/cut_fstests_local.sh
@@ -29,7 +29,9 @@ dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   fstrim fio logger dmsetup chattr lsattr cmp stat \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
-		   repquota setquota xfs_mkfile chgrp du \
+		   repquota setquota quotacheck quotaon pvremove vgremove \
+		   xfs_mkfile xfs_mdrestore xfs_metadump xfs_fsr xfsdump \
+		   chgrp du fgrep pgrep tar fgrep pgrep \
 		   $LIBS_INSTALL_LIST" \
 	--include "$FSTESTS_SRC" "/fstests" \
 	--include "$RAPIDO_DIR/fstests_local_autorun.sh" "/.profile" \


### PR DESCRIPTION
rapido1:/fstests# grep -roh ' [^ ]*: command not found' results/ | sort -u
 -v: command not found  <-- this is missing xfs_fsr
 fgrep: command not found
 pgrep: command not found
 pvremove: command not found
 quotacheck: command not found
 quotaon: command not found
 tar: command not found
 vgremove: command not found
 xfs_mdrestore: command not found
 xfs_metadump: command not found
rapido1:/fstests# grep -rh '^[^ ]* not found$' results/  | sort -u
dbench not found
xfs_fsr not found
xfsdump not found

I skipped dbench for now because it would add a new dependency.