### PR TITLE
Missing dependencies for xfstests

### DIFF
--- a/cut_fstests_cephfs.sh
+++ b/cut_fstests_cephfs.sh
@@ -18,7 +18,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 _rt_require_dracut_args
 _rt_require_ceph
 _rt_require_fstests
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
+_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_compat.so"
 
 dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs \

--- a/cut_fstests_cifs.sh
+++ b/cut_fstests_cifs.sh
@@ -17,7 +17,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 
 _rt_require_dracut_args
 _rt_require_fstests
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
+_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_compat.so"
 
 dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs \

--- a/cut_fstests_local.sh
+++ b/cut_fstests_local.sh
@@ -17,7 +17,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 
 _rt_require_dracut_args
 _rt_require_fstests
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
+_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_compat.so"
 
 dracut  --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.btrfs mkfs.xfs \


### PR DESCRIPTION
I would like to add these extra 2 dependencies for running xfstests in rapido:
- fallocate is used in several generic tests in the test-suite
- libgdbm is required to compile (and run) tests that need src/dbtest.c
