### PR TITLE
Samba atop a local FS and CephFS

### DIFF
--- a/cut_samba_cephfs.sh
+++ b/cut_samba_cephfs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2017, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})"
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_ceph
+_rt_require_samba
+_rt_require_dracut_args
+_rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
+		 libfreeblpriv3.so"	# NSS_InitContext() fails without
+
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs mkfs.xfs \
+		   which perl awk bc touch cut chmod true false \
+		   fio getfattr setfattr chacl attr killall sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   ${SAMBA_SRC}/bin/default/source3/utils/smbpasswd \
+		   ${SAMBA_SRC}/bin/modules/vfs/ceph.so \
+		   ${SAMBA_SRC}/bin/default/source3/smbd/smbd \
+		   $LIBS_INSTALL_LIST" \
+	--include "$CEPH_COMMON_LIB" "/usr/lib64/libceph-common.so.0" \
+	--include "$CEPHFS_LIB" "/usr/lib64/libcephfs.so.2" \
+	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
+	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
+	--include "$RAPIDO_DIR/samba_cephfs_autorun.sh" "/.profile" \
+	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
+	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	--modules "bash base network ifcfg" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+# assign more memory
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "1024M"

--- a/cut_samba_local.sh
+++ b/cut_samba_local.sh
@@ -24,6 +24,7 @@ _rt_require_dracut_args
 		   fio getfattr setfattr chacl attr killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
 		   ${SAMBA_SRC}/bin/default/source3/utils/smbpasswd \
+		   ${SAMBA_SRC}/bin/modules/vfs/btrfs.so \
 		   ${SAMBA_SRC}/bin/default/source3/smbd/smbd" \
 	--include "$RAPIDO_DIR/samba_local_autorun.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \

--- a/cut_samba_local.sh
+++ b/cut_samba_local.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2017, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})"
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_samba
+_rt_require_dracut_args
+
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs mkfs.btrfs mkfs.xfs \
+		   which perl awk bc touch cut chmod true false \
+		   fio getfattr setfattr chacl attr killall sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   ${SAMBA_SRC}/bin/default/source3/utils/smbpasswd \
+		   ${SAMBA_SRC}/bin/default/source3/smbd/smbd" \
+	--include "$RAPIDO_DIR/samba_local_autorun.sh" "/.profile" \
+	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
+	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	--add-drivers "zram xfs btrfs" \
+	--modules "bash base network ifcfg" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+# assign more memory
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "1024M"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -137,10 +137,15 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #FSTESTS_AUTORUN_CMD=""
 #################################
 
-######## fstests_cifs_autorun.sh ########
-# SMB/CIFS server and authentication details, used to mount the test share.
+## fstests_cifs_autorun.sh and samba_*_autorun.sh ##
+# SMB server and mount options for cifs.ko
 # e.g. CIFS_SERVER="smbserver.example.com"
 #CIFS_SERVER=""
+# e.g. CIFS_MOUNT_OPTS="vers=3.0"
+#CIFS_MOUNT_OPTS=""
+#
+# SMB/CIFS share and authentication details, used for cifs.ko mounts and Samba
+# share configuration.
 # e.g. CIFS_SHARE="myshare"
 #CIFS_SHARE=""
 # e.g. CIFS_DOMAIN="EXAMPLE"
@@ -149,9 +154,7 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #CIFS_USER=""
 # e.g. CIFS_PW="password"
 #CIFS_PW=""
-# e.g. CIFS_MOUNT_OPTS="vers=3.0"
-#CIFS_MOUNT_OPTS=""
-#################################
+####################################################
 
 ######## cut_fstests_*.sh #########
 # FSTESTS_SRC should correspond to a checkout and build of the xfstests source
@@ -191,4 +194,10 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 ###### dropbear_autorun.sh ######
 # public ssh key to add to Dropbear's authorized_keys file
 #SSH_AUTHORIZED_KEY=""
+#################################
+
+######### cut_samba_*.sh ########
+# SAMBA_SRC should correspond to a checkout and build of Samba.
+# e.g. SAMBA_SRC="/home/me/samba"
+#SAMBA_SRC=""
 #################################

--- a/runtime.vars
+++ b/runtime.vars
@@ -35,6 +35,8 @@ function _rt_ceph_src_globals_set {
 		CEPH_FUSE_BIN="${CEPH_SRC}/build/bin/ceph-fuse"
 		CEPH_RADOS_LIB="${CEPH_SRC}/build/lib/librados.so"
 		CEPH_RBD_LIB="${CEPH_SRC}/build/lib/librbd.so"
+		CEPH_COMMON_LIB="${CEPH_SRC}/build/lib/libceph-common.so.0"
+		CEPHFS_LIB="${CEPH_SRC}/build/lib/libcephfs.so.2"
 		CEPH_CONF="${CEPH_SRC}/build/ceph.conf"
 		CEPH_KEYRING="${CEPH_SRC}/build/keyring"
 	else
@@ -46,6 +48,8 @@ function _rt_ceph_src_globals_set {
 		CEPH_FUSE_BIN="${CEPH_SRC}/src/ceph-fuse"
 		CEPH_RADOS_LIB="${CEPH_SRC}/src/.libs/librados.so"
 		CEPH_RBD_LIB="${CEPH_SRC}/src/.libs/librbd.so"
+		CEPH_COMMON_LIB="${CEPH_SRC}/src/.libs/libceph-common.so.0"
+		CEPHFS_LIB="${CEPH_SRC}/src/.libs/libcephfs.so.2"
 		CEPH_CONF="${CEPH_SRC}/src/ceph.conf"
 		CEPH_KEYRING="${CEPH_SRC}/src/keyring"
 	fi
@@ -73,6 +77,8 @@ function _rt_ceph_installed_globals_set {
 	CEPH_FUSE_BIN="/usr/bin/ceph-fuse"
 	CEPH_RADOS_LIB="/usr/lib64/librados.so"
 	CEPH_RBD_LIB="/usr/lib64/librbd.so"
+	CEPH_COMMON_LIB="/usr/lib64/libceph-common.so.0"
+	CEPHFS_LIB="/usr/lib64/libcephfs.so.2"
 	CEPH_CONF="/etc/ceph/ceph.conf"
 	CEPH_KEYRING="/etc/ceph/ceph.client.${CEPH_USER}.keyring"
 }
@@ -98,6 +104,8 @@ function _rt_require_ceph {
 	[ -f "$CEPH_FUSE_BIN" ] || _fail "missing $CEPH_FUSE_BIN"
 	[ -f "$CEPH_RADOS_LIB" ] || _fail "missing $CEPH_RADOS_LIB"
 	[ -f "$CEPH_RBD_LIB" ] || _fail "missing $CEPH_RBD_LIB"
+	[ -f "$CEPH_COMMON_LIB" ] || _fail "missing $CEPH_COMMON_LIB"
+	[ -f "$CEPHFS_LIB" ] || _fail "missing $CEPHFS_LIB"
 	[ -f "$CEPH_CONF" ] || _fail "missing $CEPH_CONF"
 	[ -f "$CEPH_KEYRING" ] || _fail "missing $CEPH_KEYRING"
 }
@@ -187,6 +195,13 @@ function _rt_require_lib()
 		[ -n "$library" ] || _fail "can't find library '$libname'"
 		LIBS_INSTALL_LIST="$LIBS_INSTALL_LIST $library"
 	done
+}
+
+function _rt_require_samba {
+	[ -n "$SAMBA_SRC" ] || _fail "SAMBA_SRC is not set"
+	[ -d "$SAMBA_SRC" ] || _fail "$SAMBA_SRC is not a directory"
+	# no SAMBA_SMBD_BIN alias for now. Cut scripts should use SAMBA_SRC
+	# paths directly.
 }
 
 # initramfs output path

--- a/samba_cephfs_autorun.sh
+++ b/samba_cephfs_autorun.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2017, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+if [ ! -f /vm_autorun.env ]; then
+	echo "Error: autorun scripts must be run from within an initramfs VM"
+	exit 1
+fi
+
+. /vm_autorun.env
+
+set -x
+
+# use a non-configurable UID/GID for now
+cifs_xid="579120"
+echo "${CIFS_USER}:x:${cifs_xid}:${cifs_xid}:Samba user:/:/sbin/nologin" \
+	>> /etc/passwd
+echo "${CIFS_USER}:x:${cifs_xid}:" >> /etc/group
+
+cat /proc/mounts | grep debugfs &> /dev/null
+if [ $? -ne 0 ]; then
+	mount -t debugfs debugfs /sys/kernel/debug/
+fi
+
+cat /proc/mounts | grep configfs &> /dev/null
+if [ $? -ne 0 ]; then
+	mount -t configfs configfs /sys/kernel/config/
+fi
+
+for i in $DYN_DEBUG_MODULES; do
+	echo "module $i +pf" > /sys/kernel/debug/dynamic_debug/control || _fatal
+done
+for i in $DYN_DEBUG_FILES; do
+	echo "file $i +pf" > /sys/kernel/debug/dynamic_debug/control || _fatal
+done
+
+sed -i "s#keyring = .*#keyring = /etc/ceph/keyring#g; \
+	s#admin socket = .*##g; \
+	s#run dir = .*#run dir = /var/run/#g; \
+	s#log file = .*#log file = /var/log/\$name.\$pid.log#g" \
+	/etc/ceph/ceph.conf
+
+mkdir -p /usr/local/samba/var/
+mkdir -p /usr/local/samba/etc/
+mkdir -p /usr/local/samba/var/lock
+mkdir -p /usr/local/samba/private/
+mkdir -p /usr/local/samba/lib/
+ln -s ${SAMBA_SRC}/bin/modules/vfs/ /usr/local/samba/lib/vfs
+
+cat > /usr/local/samba/etc/smb.conf << EOF
+[global]
+	workgroup = MYGROUP
+
+[${CIFS_SHARE}]
+	path = /
+	vfs objects = ceph
+	ceph: config_file = /etc/ceph/ceph.conf
+	ceph: user_id = $CEPH_USER
+	read only = no
+EOF
+
+${SAMBA_SRC}/bin/default/source3/smbd/smbd || _fatal
+
+set +x
+
+echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
+	| ${SAMBA_SRC}/bin/default/source3/utils/smbpasswd -a $CIFS_USER -s \
+				|| _fatal
+
+ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+if [ $? -eq 0 ]; then
+	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
+fi
+ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+if [ $? -eq 0 ]; then
+	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
+fi
+echo "Log at: /usr/local/samba/var/log.smbd"

--- a/samba_local_autorun.sh
+++ b/samba_local_autorun.sh
@@ -63,14 +63,20 @@ mkdir -p /usr/local/samba/private/
 mkdir -p /usr/local/samba/lib/
 ln -s ${SAMBA_SRC}/bin/modules/vfs/ /usr/local/samba/lib/vfs
 
+smb_conf_vfs=""
+if [ "$filesystem" == "btrfs" ]; then
+	smb_conf_vfs='vfs objects = btrfs'
+fi
+
 cat > /usr/local/samba/etc/smb.conf << EOF
 [global]
 	workgroup = MYGROUP
 
 [${CIFS_SHARE}]
 	path = /mnt
-	# vfs objects = btrfs
+	$smb_conf_vfs
 	read only = no
+	store dos attributes = yes
 EOF
 
 ${SAMBA_SRC}/bin/default/source3/smbd/smbd || _fatal

--- a/samba_local_autorun.sh
+++ b/samba_local_autorun.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2017, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+if [ ! -f /vm_autorun.env ]; then
+	echo "Error: autorun scripts must be run from within an initramfs VM"
+	exit 1
+fi
+
+. /vm_autorun.env
+
+set -x
+
+filesystem="btrfs"
+
+# use a non-configurable UID/GID for now
+cifs_xid="579120"
+echo "${CIFS_USER}:x:${cifs_xid}:${cifs_xid}:Samba user:/:/sbin/nologin" \
+	>> /etc/passwd
+echo "${CIFS_USER}:x:${cifs_xid}:" >> /etc/group
+
+cat /proc/mounts | grep debugfs &> /dev/null
+if [ $? -ne 0 ]; then
+	mount -t debugfs debugfs /sys/kernel/debug/
+fi
+
+cat /proc/mounts | grep configfs &> /dev/null
+if [ $? -ne 0 ]; then
+	mount -t configfs configfs /sys/kernel/config/
+fi
+
+modprobe zram num_devices="1" || _fatal "failed to load zram module"
+
+echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"
+
+mkfs.${filesystem} /dev/zram0 || _fatal "mkfs failed"
+
+mkdir -p /mnt/
+mount -t $filesystem /dev/zram0 /mnt/ || _fatal
+chmod 777 /mnt/ || _fatal
+
+for i in $DYN_DEBUG_MODULES; do
+	echo "module $i +pf" > /sys/kernel/debug/dynamic_debug/control || _fatal
+done
+for i in $DYN_DEBUG_FILES; do
+	echo "file $i +pf" > /sys/kernel/debug/dynamic_debug/control || _fatal
+done
+
+mkdir -p /usr/local/samba/var/
+mkdir -p /usr/local/samba/etc/
+mkdir -p /usr/local/samba/var/lock
+mkdir -p /usr/local/samba/private/
+mkdir -p /usr/local/samba/lib/
+ln -s ${SAMBA_SRC}/bin/modules/vfs/ /usr/local/samba/lib/vfs
+
+cat > /usr/local/samba/etc/smb.conf << EOF
+[global]
+	workgroup = MYGROUP
+
+[${CIFS_SHARE}]
+	path = /mnt
+	# vfs objects = btrfs
+	read only = no
+EOF
+
+${SAMBA_SRC}/bin/default/source3/smbd/smbd || _fatal
+
+set +x
+
+echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
+	| ${SAMBA_SRC}/bin/default/source3/utils/smbpasswd -a $CIFS_USER -s \
+				|| _fatal
+
+ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+if [ $? -eq 0 ]; then
+	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
+fi
+ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+if [ $? -eq 0 ]; then
+	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
+fi
+echo "Log at: /usr/local/samba/var/log.smbd"


### PR DESCRIPTION
This patchset adds functionality to deploy a Samba server from source, and configure smb.conf with a share backed by CephFS or a locally provisioned zram device.