### PR TITLE
tools: use tuntap command from iproute2 instead of tunctl

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Rapido has a pretty minimal set of dependencies, which should be present
 on all major Linux distributions.
 - Dracut
 - qemu / KVM
-- tunctl for VM network provisioning
+- iproute2 with 'ip tuntap' support
 
 Once all dependencies have been installed, Rapido can be configured via
 rapido.conf. At a minimum, the VM network configuration and Linux kernel

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -15,8 +15,6 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-TUNCTL=$(which tunctl) || _fail "tunctl missing"
-
 # cleanup on premature exit by executing whatever has been prepended to @unwind
 unwind=""
 trap "eval \$unwind" 0 1 2 3 15
@@ -38,14 +36,14 @@ fi
 echo
 
 # setup tap interfaces for VMs
-$TUNCTL -u $TAP_USER -t $TAP_DEV0 || exit 1
-unwind="$TUNCTL -d $TAP_DEV0; ${unwind}"
+ip tuntap add dev $TAP_DEV0 mode tap user $TAP_USER || exit 1
+unwind="ip tuntap delete dev $TAP_DEV0 mode tap; ${unwind}"
 ip link set $TAP_DEV0 master $BR_DEV || exit 1
 unwind="ip link set $TAP_DEV0 nomaster; ${unwind}"
 echo "+ created $TAP_DEV0"
 
-$TUNCTL -u $TAP_USER -t $TAP_DEV1 || exit 1
-unwind="$TUNCTL -d $TAP_DEV1; ${unwind}"
+ip tuntap add dev $TAP_DEV1 mode tap user $TAP_USER || exit 1
+unwind="ip tuntap delete dev $TAP_DEV1 mode tap; ${unwind}"
 ip link set $TAP_DEV1 master $BR_DEV || exit 1
 unwind="ip link set $TAP_DEV1 nomaster; ${unwind}"
 echo "+ created $TAP_DEV1"

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -17,8 +17,6 @@ RAPIDO_DIR="`dirname $0`/.."
 
 set -x
 
-TUNCTL=$(which tunctl) || _fail "tunctl missing"
-
 if [ -n "$BR_DHCP_SRV_RANGE" ]; then
 	dnsmasq_pid=`ps -eo pid,args | grep -v grep | grep dnsmasq \
 			| grep -- --interface=$BR_DEV \
@@ -36,10 +34,10 @@ ip link set dev $TAP_DEV0 down || exit 1
 ip link set dev $BR_DEV down || exit 1
 
 ip link set $TAP_DEV1 nomaster || exit 1
-$TUNCTL -d $TAP_DEV1 || exit 1
+ip tuntap delete dev $TAP_DEV1 mode tap || exit 1
 
 ip link set $TAP_DEV0 nomaster || exit 1
-$TUNCTL -d $TAP_DEV0 || exit 1
+ip tuntap delete dev $TAP_DEV0 mode tap || exit 1
 
 if [ -n "$BR_IF" ]; then
 	ip link set $BR_IF nomaster || exit 1

--- a/tools/setup_br_ip_takeover.sh
+++ b/tools/setup_br_ip_takeover.sh
@@ -57,7 +57,6 @@ function _apply_addrs() {
 	done < $addrs_file
 }
 
-TUNCTL=$(which tunctl) || _fail "tunctl missing"
 [ -z "$BR_ADDR" ] || _fail "BR_ADDR setting incompatible with ip takeover"
 [ -n "$BR_DEV" ] || _fail "BR_DEV required for IP takeover"
 [ -n "$BR_IF" ] || _fail "BR_IF required for IP takeover"
@@ -105,15 +104,15 @@ unwind="ip link set dev $BR_DEV down; ${unwind}"
 _apply_routes add "$BR_DEV" "${BR_IF_DUMP_DIR}/routes" || exit 1
 
 # setup tap interfaces for VMs
-$TUNCTL -u $TAP_USER -t $TAP_DEV0 || exit 1
-unwind="$TUNCTL -d $TAP_DEV0; ${unwind}"
+ip tuntap add dev $TAP_DEV0 mode tap user $TAP_USER || exit 1
+unwind="ip tuntap delete dev $TAP_DEV0 mode tap; ${unwind}"
 ip link set $TAP_DEV0 master $BR_DEV || exit 1
 unwind="ip link set $TAP_DEV0 nomaster; ${unwind}"
 ip link set $TAP_DEV0 up
 unwind="ip link set $TAP_DEV0 down; ${unwind}"
 
-$TUNCTL -u $TAP_USER -t $TAP_DEV1 || exit 1
-unwind="$TUNCTL -d $TAP_DEV1; ${unwind}"
+ip tuntap add dev $TAP_DEV1 mode tap user $TAP_USER || exit 1
+unwind="ip tuntap delete dev $TAP_DEV1 mode tap; ${unwind}"
 ip link set $TAP_DEV1 master $BR_DEV || exit 1
 unwind="ip link set $TAP_DEV1 nomaster; ${unwind}"
 ip link set $TAP_DEV1 up


### PR DESCRIPTION
tunctl is deprecated and will be remove from SLE15 base, so replace
all calls to tunctl with it's ip route2 equivalent.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>