### PR TITLE
cut: call dracut with --no-early-microcode by default

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -152,7 +152,7 @@ function _rt_require_dracut_args() {
 
 	local dracut_args="--no-compress --no-hostonly --no-hostonly-cmdline \
 			   --force --tmpdir $RAPIDO_DIR/initrds/ \
-			   --kver $kver"
+			   --kver $kver --no-early-microcode"
 
 	if [ -n "$DRACUT_SRC" ]; then
 		DRACUT="$DRACUT_SRC/dracut.sh"


### PR DESCRIPTION
--no-early-microcode ensures that an unnecessary "early microcode" CPIO
image isn't nested in Rapido initramfs images. On my laptop it
significantly speeds up image creation, and reduces size by ~3MB!:
(before)
	> time ./cut_simple_example.sh
	...
	real    0m1.153s
	user    0m0.927s
	sys     0m0.401s

	> l initrds/myinitrd
	-rw------- 1 ddiss users 16229888 May 13 21:22 initrds/myinitrd

(after)
	> time ./cut_simple_example.sh
	...
	real    0m1.060s
	user    0m0.889s
	sys     0m0.348s

	> l initrds/myinitrd
	-rw------- 1 ddiss users 12892672 May 13 21:24 initrds/myinitrd

Signed-off-by: David Disseldorp <ddiss@suse.de>