### PR TITLE
openiscsi: add cut and autorun

### DIFF
--- a/cut_openiscsi.sh
+++ b/cut_openiscsi.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2018, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})"
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args
+_rt_require_conf_dir OPENISCSI_SRC
+
+"$DRACUT" \
+	--install "grep ps dd mkfs.xfs \
+		   ${OPENISCSI_SRC}/usr/iscsid \
+		   ${OPENISCSI_SRC}/libopeniscsiusr/libopeniscsiusr.so \
+		   ${OPENISCSI_SRC}/usr/iscsiadm" \
+	--include "${RAPIDO_DIR}/openiscsi_autorun.sh" "/.profile" \
+	--include "${RAPIDO_DIR}/rapido.conf" "/rapido.conf" \
+	--include "${RAPIDO_DIR}/vm_autorun.env" "/vm_autorun.env" \
+	--modules "bash base network ifcfg" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"

--- a/openiscsi_autorun.sh
+++ b/openiscsi_autorun.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2018, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+if [ ! -f /vm_autorun.env ]; then
+	echo "Error: autorun scripts must be run from within an initramfs VM"
+	exit 1
+fi
+
+. /vm_autorun.env
+
+set -x
+
+_vm_ar_dyn_debug_enable
+
+mkdir -p /etc/iscsi
+[ -n "$INITIATOR_IQNS" ] \
+	|| _fatal "INITIATOR_IQNS config required for InitiatorName"
+inames=( $INITIATOR_IQNS )
+echo "InitiatorName=${inames[0]}" > /etc/iscsi/initiatorname.iscsi
+
+for i in $(ls ${OPENISCSI_SRC}/libopeniscsiusr/*.so*); do
+	ln -s $i /lib64/ || _fatal
+done
+
+${OPENISCSI_SRC}/usr/iscsid || _fatal
+
+[ -n "$INITIATOR_DISCOVERY_ADDR" ] \
+	|| _fatal "INITIATOR_DISCOVERY_ADDR config required for SendTargets"
+${OPENISCSI_SRC}/usr/iscsiadm -m discovery -t sendtargets \
+				-p $INITIATOR_DISCOVERY_ADDR || _fatal
+# login to all discovered targets
+${OPENISCSI_SRC}/usr/iscsiadm -m node -l all || _fatal
+set +x

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -211,3 +211,13 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #RTSLIB_SRC=""
 #CONFIGSHELL_SRC=""
 ################################
+
+########## openiscsi ###########
+# OPENISCSI_SRC should correspond to a checkout and build of open-iscsi
+#OPENISCSI_SRC=""
+# openiscsi_autorun.sh uses the first entry in INITIATOR_IQNS as the
+# InitiatorName.
+# INITIATOR_DISCOVERY_ADDR is the hostname or IP address that will be used
+# when issuing a SendTargets discovery request.
+#INITIATOR_DISCOVERY_ADDR=""
+################################


### PR DESCRIPTION
Generate an image with iscsid and iscsiadm from OPENISCSI_SRC. On boot,
connect to the target at INITIATOR_DISCOVERY_ADDR, issue a SendTargets
request and then login to any discovered targets.

Signed-off-by: David Disseldorp <ddiss@suse.de>