### PR TITLE
fstests: fix cephfs, cifs and xfs

### DIFF
--- a/autorun/fstests_cephfs.sh
+++ b/autorun/fstests_cephfs.sh
@@ -21,9 +21,6 @@ fi
 
 set -x
 
-# path to xfstests within the initramfs
-XFSTESTS_DIR="/fstests"
-
 hostname_fqn="`cat /proc/sys/kernel/hostname`" || _fatal "hostname unavailable"
 hostname_short="${hostname_fqn%%.*}"
 
@@ -49,7 +46,11 @@ mkdir -p /mnt/test
 mount -t ceph ${MON_ADDRESS}:/ /mnt/test -o name=${CEPH_USER},secret=${key} \
 	|| _fatal
 
-cat > ${XFSTESTS_DIR}/configs/`hostname -s`.config << EOF
+[ -n "${FSTESTS_SRC}" ] || _fatal "FSTESTS_SRC unset"
+[ -d "${FSTESTS_SRC}" ] || _fatal "$FSTESTS_SRC missing"
+
+cfg="${FSTESTS_SRC}/configs/$(hostname -s).config"
+cat > $cfg << EOF
 MODULAR=0
 TEST_DIR=/mnt/test
 TEST_DEV=${MON_ADDRESS}:/
@@ -60,6 +61,6 @@ EOF
 set +x
 
 if [ -n "$FSTESTS_AUTORUN_CMD" ]; then
-	cd ${XFSTESTS_DIR} || _fatal
+	cd ${FSTESTS_SRC} || _fatal
 	eval "$FSTESTS_AUTORUN_CMD"
 fi

--- a/autorun/fstests_cifs.sh
+++ b/autorun/fstests_cifs.sh
@@ -21,9 +21,6 @@ fi
 
 set -x
 
-# path to xfstests within the initramfs
-XFSTESTS_DIR="/fstests"
-
 hostname_fqn="`cat /proc/sys/kernel/hostname`" || _fatal "hostname unavailable"
 hostname_short="${hostname_fqn%%.*}"
 
@@ -47,16 +44,21 @@ mkdir -p /mnt/test
 mount -t cifs //${CIFS_SERVER}/${CIFS_SHARE} /mnt/test \
 	"$mount_args" || _fatal
 
-cat > ${XFSTESTS_DIR}/configs/`hostname -s`.config << EOF
+[ -n "${FSTESTS_SRC}" ] || _fatal "FSTESTS_SRC unset"
+[ -d "${FSTESTS_SRC}" ] || _fatal "$FSTESTS_SRC missing"
+
+cfg="${FSTESTS_SRC}/configs/$(hostname -s).config"
+cat > $cfg << EOF
 MODULAR=0
 TEST_DIR=/mnt/test
 TEST_DEV=//${CIFS_SERVER}/${CIFS_SHARE}
 TEST_FS_MOUNT_OPTS="$mount_args"
+FSTYP="cifs"
 EOF
 
 set +x
 
 if [ -n "$FSTESTS_AUTORUN_CMD" ]; then
-	cd ${XFSTESTS_DIR} || _fatal
+	cd ${FSTESTS_SRC} || _fatal
 	eval "$FSTESTS_AUTORUN_CMD"
 fi

--- a/cut_fstests_btrfs.sh
+++ b/cut_fstests_btrfs.sh
@@ -23,7 +23,7 @@ _rt_require_fstests
 		   which perl awk bc touch cut chmod true false unlink \
 		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep \
+		   basename tee egrep yes \
 		   fstrim fio logger dmsetup chattr lsattr cmp stat \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \

--- a/cut_fstests_btrfs.sh
+++ b/cut_fstests_btrfs.sh
@@ -19,7 +19,7 @@ _rt_require_dracut_args
 _rt_require_fstests
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.btrfs btrfs \
+		   strace mkfs mkfs.btrfs btrfs btrfs-convert btrfstune \
 		   which perl awk bc touch cut chmod true false unlink \
 		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \

--- a/cut_fstests_cephfs.sh
+++ b/cut_fstests_cephfs.sh
@@ -24,7 +24,7 @@ _rt_require_fstests
 		   which perl awk bc touch cut chmod true false unlink \
 		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep \
+		   basename tee egrep yes \
 		   fstrim fio logger dmsetup chattr lsattr cmp stat \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \

--- a/cut_fstests_cephfs.sh
+++ b/cut_fstests_cephfs.sh
@@ -18,21 +18,23 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 _rt_require_dracut_args
 _rt_require_ceph
 _rt_require_fstests
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_compat.so"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.xfs \
+		   strace mkfs \
 		   which perl awk bc touch cut chmod true false unlink \
-		   mktemp getfattr setfattr chacl attr killall \
+		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep hexdump sync xfs_db xfs_io \
+		   basename tee egrep \
 		   fstrim fio logger dmsetup chattr lsattr cmp stat \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
-		   repquota setquota quotacheck quotaon xfs_mkfile \
+		   repquota setquota quotacheck quotaon pvremove vgremove \
+		   xfs_mkfile xfs_db xfs_io \
 		   chgrp du fgrep pgrep tar rev kill \
-		   $LIBS_INSTALL_LIST" \
-	--include "$FSTESTS_SRC" "/fstests" \
+		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${FSTESTS_SRC}/src/log-writes/* \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--include "$CEPH_MOUNT_BIN" "/sbin/mount.ceph" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
@@ -41,4 +43,6 @@ _rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--modules "bash base network ifcfg" \
 	$DRACUT_EXTRA_ARGS \
-	$DRACUT_OUT
+	$DRACUT_OUT || _fail "dracut failed"
+
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "2048M"

--- a/cut_fstests_cifs.sh
+++ b/cut_fstests_cifs.sh
@@ -17,27 +17,29 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 
 _rt_require_dracut_args
 _rt_require_fstests
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_compat.so"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.xfs \
+		   strace mkfs mount.cifs \
 		   which perl awk bc touch cut chmod true false unlink \
-		   mktemp getfattr setfattr chacl attr killall \
+		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep hexdump sync xfs_db xfs_io mount.cifs \
+		   basename tee egrep \
 		   fstrim fio logger dmsetup chattr lsattr cmp stat \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
-		   repquota setquota quotacheck quotaon xfs_mkfile \
+		   repquota setquota quotacheck quotaon pvremove vgremove \
+		   xfs_mkfile xfs_db xfs_io \
 		   chgrp du fgrep pgrep tar rev kill \
-		   $LIBS_INSTALL_LIST" \
-	--include "$FSTESTS_SRC" "/fstests" \
+		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${FSTESTS_SRC}/src/log-writes/* \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--include "$RAPIDO_DIR/autorun/fstests_cifs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--add-drivers "cifs ccm ctr" \
 	--modules "bash base network ifcfg" \
 	$DRACUT_EXTRA_ARGS \
-	$DRACUT_OUT
+	$DRACUT_OUT || _fail "dracut failed"
 
 _rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "2048M"

--- a/cut_fstests_cifs.sh
+++ b/cut_fstests_cifs.sh
@@ -23,7 +23,7 @@ _rt_require_fstests
 		   which perl awk bc touch cut chmod true false unlink \
 		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep \
+		   basename tee egrep yes \
 		   fstrim fio logger dmsetup chattr lsattr cmp stat \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \

--- a/cut_fstests_xfs.sh
+++ b/cut_fstests_xfs.sh
@@ -17,7 +17,6 @@ RAPIDO_DIR="$(realpath -e ${0%/*})"
 
 _rt_require_dracut_args
 _rt_require_fstests
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_compat.so"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs \
@@ -32,8 +31,10 @@ _rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1 libgdbm.so libgdbm_
 		   repquota setquota quotacheck quotaon pvremove vgremove \
 		   xfs_mkfile xfs_mdrestore xfs_metadump xfs_fsr xfsdump \
 		   chgrp du fgrep pgrep tar rev kill \
-		   $LIBS_INSTALL_LIST" \
-	--include "$FSTESTS_SRC" "/fstests" \
+		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${FSTESTS_SRC}/src/log-writes/* \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--include "$RAPIDO_DIR/autorun/fstests_xfs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \

--- a/cut_fstests_xfs.sh
+++ b/cut_fstests_xfs.sh
@@ -23,13 +23,14 @@ _rt_require_fstests
 		   which perl awk bc touch cut chmod true false unlink \
 		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep xfs_freeze xfs_db xfs_io xfs_info \
-		   xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_bmap \
+		   basename tee egrep yes \
 		   fstrim fio logger dmsetup chattr lsattr cmp stat \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
 		   repquota setquota quotacheck quotaon pvremove vgremove \
-		   xfs_mkfile xfs_mdrestore xfs_metadump xfs_fsr xfsdump \
+		   xfs_mkfile xfs_db xfs_io \
+		   xfs_mdrestore xfs_bmap xfs_fsr xfsdump xfs_freeze xfs_info \
+		   xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_metadump \
 		   chgrp du fgrep pgrep tar rev kill \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \


### PR DESCRIPTION
The first commit was accidentally left out with https://github.com/rapido-linux/rapido/pull/59 . The second commit is something I came across while testing.