### PR TITLE
cut_fstests: add "duperemove" dependency for btrfs and xfs

### DIFF
--- a/cut_fstests_btrfs.sh
+++ b/cut_fstests_btrfs.sh
@@ -29,7 +29,7 @@ _rt_require_fstests
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
 		   repquota setquota quotacheck quotaon pvremove vgremove \
 		   xfs_mkfile xfs_db xfs_io \
-		   chgrp du fgrep pgrep tar rev kill \
+		   chgrp du fgrep pgrep tar rev kill duperemove \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \

--- a/cut_fstests_xfs.sh
+++ b/cut_fstests_xfs.sh
@@ -31,7 +31,7 @@ _rt_require_fstests
 		   xfs_mkfile xfs_db xfs_io \
 		   xfs_mdrestore xfs_bmap xfs_fsr xfsdump xfs_freeze xfs_info \
 		   xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_metadump \
-		   chgrp du fgrep pgrep tar rev kill \
+		   chgrp du fgrep pgrep tar rev kill duperemove \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \


### PR DESCRIPTION
shared/008,009 and 010 on btrfs and xfs need duperemove to run, provide it
to increase test coverage.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>