### PR TITLE
Fix cephfs_fuse

### DIFF
--- a/autorun/cephfs_fuse.sh
+++ b/autorun/cephfs_fuse.sh
@@ -18,6 +18,7 @@ if [ ! -f /vm_autorun.env ]; then
 fi
 
 . /vm_autorun.env
+. /vm_ceph.env || _fatal
 
 set -x
 
@@ -31,5 +32,5 @@ sed -i "s#keyring = .*#keyring = /etc/ceph/keyring#g; \
 	s#log file = .*#log file = /var/log/\$name.\$pid.log#g" \
 	/etc/ceph/ceph.conf
 mkdir -p /mnt/cephfs
-ceph-fuse /mnt/cephfs
+$CEPH_FUSE_BIN /mnt/cephfs || _fatal
 set +x

--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -15,22 +15,28 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_ceph
-_rt_require_dracut_args
-_rt_require_lib "libkeyutils.so.1 libfuse.so libcryptopp-5.6.2.so.0 libhandle.so.1 libssl.so.1"
+vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
+# remove tmp file once we're done
+trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.xfs \
-		   which perl awk bc touch cut chmod true false \
-		   fio getfattr setfattr chacl attr killall sync \
-		   id sort uniq date expr tac diff head dirname seq ip ping \
+_rt_require_ceph
+_rt_write_ceph_config $vm_ceph_conf
+_rt_write_ceph_bin_paths $vm_ceph_conf
+_rt_require_dracut_args
+_rt_require_lib "libsoftokn3.so \
+		 libfreeblpriv3.so"	# NSS_InitContext() fails without
+
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
+		   strace stat truncate touch cut chmod fio getfattr setfattr \
+		   chacl attr killall sync dirname seq ip ping \
+		   $CEPH_FUSE_BIN \
 		   $LIBS_INSTALL_LIST" \
-	--include "$CEPH_FUSE_BIN" "/bin/ceph-fuse" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RAPIDO_DIR/autorun/cephfs_fuse.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "fuse" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/runtime.vars
+++ b/runtime.vars
@@ -130,6 +130,24 @@ function _rt_write_ceph_config() {
 	[ -n "$value" ] && echo "CEPH_ROOT_INO_GID=$value" >> $vm_ceph_conf
 }
 
+# Ceph binaries and libraries can be sourced from CEPH_SRC or locally installed
+# system paths.
+# This helper allows cut scripts to use dracut --install "CEPH_X_BIN" (which
+# pulls in ldd dependencies, as opposed to --include "CEPH_X_BIN" "$tgt"), and
+# then use those paths directly in the autorun script (after including
+# vm_ceph.env).
+function _rt_write_ceph_bin_paths() {
+	local vm_ceph_conf=$1
+
+	[ -f "$vm_ceph_conf" ] || _fail "missing file $vm_ceph_conf"
+	# sanity check. _rt_require_ceph() should have already done this...
+	[ -f "$CEPH_MOUNT_BIN" ] || _fail "missing $CEPH_MOUNT_BIN"
+	[ -f "$CEPH_FUSE_BIN" ] || _fail "missing $CEPH_FUSE_BIN"
+
+	echo "CEPH_MOUNT_BIN=${CEPH_MOUNT_BIN}" >> $vm_ceph_conf
+	echo "CEPH_FUSE_BIN=${CEPH_FUSE_BIN}" >> $vm_ceph_conf
+}
+
 function _rt_require_fstests() {
 	_rt_require_conf_dir FSTESTS_SRC
 	[ -x "$FSTESTS_SRC/check" ] || _fail "missing $FSTESTS_SRC/check"


### PR DESCRIPTION
I ran into a few issues with library dependencies following SES6 upgrade. This should make things a little more robust by relying on dracut's ldd dependency lookup behaviour.