### PR TITLE
samba_kernel_cephfs: kernel-backed Samba share runner

### DIFF
--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+if [ ! -f /vm_autorun.env ]; then
+	echo "Error: autorun scripts must be run from within an initramfs VM"
+	exit 1
+fi
+
+. /vm_autorun.env
+. /vm_ceph.env || _fatal
+
+set -x
+
+_vm_ar_dyn_debug_enable
+
+export PATH="${SAMBA_SRC}/bin/:${PATH}"
+
+# use a uid and gid which match the CephFS root owner, so SMB users can perform
+# I/O without needing to chmod.
+echo "${CIFS_USER}:x:${CEPH_ROOT_INO_UID-0}:${CEPH_ROOT_INO_GID-0}:Samba user:/:/sbin/nologin" \
+	>> /etc/passwd
+echo "${CIFS_USER}:x:${CEPH_ROOT_INO_GID-0}:" >> /etc/group
+
+mkdir -p /mnt/cephfs
+mount -t ceph ${CEPH_MON_ADDRESS_V1}:/ /mnt/cephfs \
+	-o name=${CEPH_USER},secret=${CEPH_USER_KEY} || _fatal
+
+mkdir -p /usr/local/samba/var/
+mkdir -p /usr/local/samba/etc/
+mkdir -p /usr/local/samba/var/lock
+mkdir -p /usr/local/samba/private/
+mkdir -p /usr/local/samba/lib/
+ln -s ${SAMBA_SRC}/bin/modules/vfs/ /usr/local/samba/lib/vfs
+
+cat > /usr/local/samba/etc/smb.conf << EOF
+[global]
+	workgroup = MYGROUP
+	load printers = no
+	smbd: backgroundqueue = no
+
+[${CIFS_SHARE}]
+	path = /mnt/cephfs
+	read only = no
+	# no flock support
+	kernel share modes = no
+	# no kernel oplock support
+	oplocks = no
+EOF
+
+smbd || _fatal
+
+set +x
+
+echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
+	| smbpasswd -a $CIFS_USER -s || _fatal
+
+ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+if [ $? -eq 0 ]; then
+	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
+fi
+ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+if [ $? -eq 0 ]; then
+	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
+fi
+echo "Log at: /usr/local/samba/var/log.smbd"

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
+# remove tmp file once we're done
+trap "rm $vm_ceph_conf" 0 1 2 3 15
+
+_rt_require_dracut_args
+_rt_require_ceph
+_rt_write_ceph_config $vm_ceph_conf
+_rt_require_conf_dir SAMBA_SRC
+_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
+
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace stat which touch cut chmod true false \
+		   fio getfattr setfattr getfacl setfacl killall sync \
+		   id sort uniq date expr tac diff head dirname seq ip ping \
+		   ${SAMBA_SRC}/bin/smbpasswd \
+		   ${SAMBA_SRC}/bin/smbd \
+		   $LIBS_INSTALL_LIST" \
+	--include "$CEPH_MOUNT_BIN" "/sbin/mount.ceph" \
+	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
+	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
+	--include "$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh" "/.profile" \
+	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
+	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	--include "$vm_ceph_conf" "/vm_ceph.env" \
+	--add-drivers "ceph libceph" \
+	--modules "bash base" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+# assign more memory
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "1024M"


### PR DESCRIPTION
This mostly matches samba_cephfs, but uses a kernel CephFS mountpoint
instead of libcephfs for filesystem I/O.

Signed-off-by: David Disseldorp <ddiss@suse.de>