### PR TITLE
Add support for LTP

### DIFF
--- a/autorun/ltp.sh
+++ b/autorun/ltp.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+
+if [ ! -f /vm_autorun.env ]; then
+	echo "Error: autorun scripts must be run from within an initramfs VM"
+	exit 1
+fi
+
+. /vm_autorun.env
+
+LTP_DIR="/opt/ltp"
+[ -d "$LTP_DIR" ] || _fatal "LTP missing"
+
+_vm_ar_dyn_debug_enable
+
+set -x
+
+echo "running LTP Test $LTP_AUTORUN_CMD" 
+#
+if [ -n "$LTP_AUTORUN_CMD" ]; then
+        cd ${LTP_DIR} || _fatal
+        eval "$LTP_AUTORUN_CMD"
+fi
+

--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LINUX GmbH 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args
+_rt_require_conf_dir LTP_BIN
+
+"$DRACUT" \
+	--install "ps rmdir dd mkfs.xfs" \
+	--include "$RAPIDO_DIR/autorun/ltp.sh" "/.profile" \
+	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
+	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	--include "$LTP_BIN" "/opt/ltp"  \
+	--add-drivers "zram lzo lzo-rle" \
+	--modules "bash base" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+_rt_xattr_vm_networkless_set "$DRACUT_OUT"		# *disable* network
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "2048M"	# 2 vCPUs, 2G RAM

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -227,3 +227,12 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 # when issuing a SendTargets discovery request.
 #INITIATOR_DISCOVERY_ADDR=""
 ################################
+
+########## cut/ltp.sh ##########
+# LTP_BIN should correspond to the ltp binary tree after make install 
+# make sure you run LTP's configure script with a prefix somewhere under your
+# home directory
+#LTP_BIN=
+# LTP_AUTORUN_CMD can be set to automatically run one or more ltp testcases
+#LTP_AUTORUN_CMD
+################################


### PR DESCRIPTION
The Linux Test Project [1] is a collection of tools for testing the
Linux kernel and related features.
These tests can/will harm the system you run them on, so running them
inside virtual machines is neccessary for developing new testcases.

Rapido can build a ramdisk image with the complete LTP binaries and
execute a single test or the included testrunner.

[1] https://github.com/linux-test-project/ltp/

Signed-off-by: Michael Moese <mmoese@suse.de>