### PR TITLE
add virtio-rng-pci device and update samba dependencies

### DIFF
--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -26,10 +26,9 @@ _rt_require_conf_dir SAMBA_SRC
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.xfs \
-		   which perl awk bc touch cut chmod true false \
-		   fio getfattr setfattr chacl attr killall sync \
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
+		   which touch cut chmod true false \
+		   getfattr setfattr chacl attr killall sync \
 		   id sort uniq date expr tac diff head dirname seq ip ping \
 		   ${SAMBA_SRC}/bin/smbpasswd \
 		   ${SAMBA_SRC}/bin/modules/vfs/ceph.so \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -25,9 +25,9 @@ _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC
 _rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
 		   strace stat which touch cut chmod true false \
-		   fio getfattr setfattr getfacl setfacl killall sync \
+		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq ip ping \
 		   ${SAMBA_SRC}/bin/smbpasswd \
 		   ${SAMBA_SRC}/bin/smbd \

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -18,10 +18,10 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args
 _rt_require_conf_dir SAMBA_SRC
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.btrfs mkfs.xfs \
-		   which perl awk bc touch cut chmod true false \
-		   fio getfattr setfattr chacl attr killall sync \
+		   stat which touch cut chmod true false \
+		   getfattr setfattr chacl attr killall sync \
 		   id sort uniq date expr tac diff head dirname seq ip ping \
 		   ${SAMBA_SRC}/bin/smbpasswd \
 		   ${SAMBA_SRC}/bin/modules/vfs/btrfs.so \

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -39,9 +39,8 @@ TAP_USER=""
 # hypervisor for random number generation.
 #
 # e.g. QEMU_EXTRA_ARGS="-nographic -drive file=/dev/sdz,if=virtio,cache=none,format=raw,index=0"
-# e.g. QEMU_EXTRA_ARGS="-nographic -gdb tcp:127.0.0.1:1234"
-# e.g. QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
-QEMU_EXTRA_ARGS="-nographic"
+# e.g. QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci -gdb tcp:127.0.0.1:1234"
+QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 
 # extra dracut args, e.g. "--debug"
 #DRACUT_EXTRA_ARGS=""


### PR DESCRIPTION
@rjfd hit https://github.com/rapido-linux/rapido/issues/44 while playing with Rapido, so I think it's time we add the virtio-rng-pci device to the default qemu parameter list.