### PR TITLE
rapido: add 'vm' alias for 'boot'

### DIFF
--- a/rapido
+++ b/rapido
@@ -28,6 +28,12 @@ rapido_setup_network()
 	${RAPIDO_DIR}/tools/br_setup.sh
 }
 
+short_help["vm"]="Boot previously prepared test"
+rapido_vm()
+{
+	${RAPIDO_DIR}/vm.sh
+}
+
 short_help["boot"]="Boot previously prepared test"
 rapido_boot()
 {


### PR DESCRIPTION
I find myself mistyping './rapido vm' instead of './rapido boot' several
times a day, so just add a that command.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>