### PR TITLE
vm: use qemu virtio network devices

### DIFF
--- a/vm.sh
+++ b/vm.sh
@@ -65,7 +65,7 @@ function _vm_start
 				|| _fail "IP_ADDR${vm_num} not configured"
 			kern_ip_addr="${ip_addr}:::255.255.255.0:${hostname}"
 		fi
-		qemu_netdev="-device e1000,netdev=nw1,mac=${mac_addr} \
+		qemu_netdev="-device virtio-net,netdev=nw1,mac=${mac_addr} \
 			-netdev tap,id=nw1,script=no,downscript=no,ifname=${tap}"
 	fi
 


### PR DESCRIPTION
On my system this speeds up time to /init for a network attached VM with
static IP from 3.143863s to 0.735700s - a >4X improvement.

kernel/*config files already include CONFIG_VIRTIO_NET=y, so no other
changes should be needed.

Signed-off-by: David Disseldorp <ddiss@suse.de>