### PR TITLE
rapido: add fsqa user to fstests tests

### DIFF
--- a/autorun/fstests_btrfs.sh
+++ b/autorun/fstests_btrfs.sh
@@ -62,6 +62,10 @@ SCRATCH_MNT=/mnt/scratch
 SCRATCH_DEV_POOL="/dev/zram1 /dev/zram2 /dev/zram3 /dev/zram4"
 EOF
 
+mkdir -p home/fsgqa
+groupadd fsgqa
+useradd -g fsgqa fsgqa
+
 set +x
 
 echo "$filesystem filesystem ready for FSQA"

--- a/autorun/fstests_cephfs.sh
+++ b/autorun/fstests_cephfs.sh
@@ -48,6 +48,10 @@ TEST_FS_MOUNT_OPTS="-o name=${CEPH_USER},secret=${CEPH_USER_KEY}"
 FSTYP="ceph"
 EOF
 
+mkdir -p home/fsgqa
+groupadd fsgqa
+useradd -g fsgqa fsgqa
+
 set +x
 
 if [ -n "$FSTESTS_AUTORUN_CMD" ]; then

--- a/autorun/fstests_cifs.sh
+++ b/autorun/fstests_cifs.sh
@@ -56,6 +56,10 @@ TEST_FS_MOUNT_OPTS="$mount_args"
 FSTYP="cifs"
 EOF
 
+mkdir -p home/fsgqa
+groupadd fsgqa
+useradd -g fsgqa fsgqa
+
 set +x
 
 if [ -n "$FSTESTS_AUTORUN_CMD" ]; then

--- a/autorun/fstests_xfs.sh
+++ b/autorun/fstests_xfs.sh
@@ -56,6 +56,10 @@ SCRATCH_MNT=/mnt/scratch
 SCRATCH_DEV=/dev/zram1
 EOF
 
+mkdir -p home/fsgqa
+groupadd fsgqa
+useradd -g fsgqa fsgqa
+
 set +x
 
 echo "$filesystem filesystem ready for FSQA"

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -30,16 +30,20 @@ _rt_require_btrfs_progs
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
 		   repquota setquota quotacheck quotaon pvremove vgremove \
 		   xfs_mkfile xfs_db xfs_io \
-		   chgrp du fgrep pgrep tar rev kill duperemove \
+		   chgrp du fgrep pgrep tar rev kill duperemove useradd groupadd \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*
 		   $BTRFS_PROGS_BINS" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	--include "/lib64/security/pam_permit.so" "/lib64/security/pam_permit.so" \
+	--include "/etc/pam.d/useradd" "/etc/pam.d/useradd" \
+	--include "/etc/pam.d/groupadd" "/etc/pam.d/groupadd" \
 	--include "$RAPIDO_DIR/autorun/fstests_btrfs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq" \
+	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
+			xxhash_generic" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -36,12 +36,15 @@ _rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
 		   repquota setquota quotacheck quotaon pvremove vgremove \
 		   xfs_mkfile xfs_db xfs_io \
-		   chgrp du fgrep pgrep tar rev kill ip ping \
+		   chgrp du fgrep pgrep tar rev kill ip ping useradd groupadd \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/* \
 		   $LIBS_INSTALL_LIST" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	--include "/lib64/security/pam_permit.so" "/lib64/security/pam_permit.so" \
+	--include "/etc/pam.d/useradd" "/etc/pam.d/useradd" \
+	--include "/etc/pam.d/groupadd" "/etc/pam.d/groupadd" \
 	--include "$CEPH_MOUNT_BIN" "/sbin/mount.ceph" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -29,11 +29,14 @@ _rt_require_fstests
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
 		   repquota setquota quotacheck quotaon pvremove vgremove \
 		   xfs_mkfile xfs_db xfs_io \
-		   chgrp du fgrep pgrep tar rev kill ip ping \
+		   chgrp du fgrep pgrep tar rev kill ip ping useradd groupadd \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	--include "/lib64/security/pam_permit.so" "/lib64/security/pam_permit.so" \
+	--include "/etc/pam.d/useradd" "/etc/pam.d/useradd" \
+	--include "/etc/pam.d/groupadd" "/etc/pam.d/groupadd" \
 	--include "$RAPIDO_DIR/autorun/fstests_cifs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -31,11 +31,14 @@ _rt_require_fstests
 		   xfs_mkfile xfs_db xfs_io \
 		   xfs_mdrestore xfs_bmap xfs_fsr xfsdump xfs_freeze xfs_info \
 		   xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_metadump \
-		   chgrp du fgrep pgrep tar rev kill duperemove \
+		   chgrp du fgrep pgrep tar rev kill duperemove useradd groupadd \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	--include "/lib64/security/pam_permit.so" "/lib64/security/pam_permit.so" \
+	--include "/etc/pam.d/useradd" "/etc/pam.d/useradd" \
+	--include "/etc/pam.d/groupadd" "/etc/pam.d/groupadd" \
 	--include "$RAPIDO_DIR/autorun/fstests_xfs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \


### PR DESCRIPTION
Some fstests tests require the fsqa user to be present otherwise they will
be skipped.

Add everything neccessary to add the fsqa user to fstests cut scripts and
add a fsqa user and group for the fstest autorun scripts.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>