### PR TITLE
LTP: add few more dependencies

### DIFF
--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -25,7 +25,8 @@ _rt_require_conf_dir LTP_DIR
 		diff head dirname seq basename tee egrep yes dmsetup chattr \
 		lsattr cmp stat hostname getconf md5sum od wc tr xargs sysctl \
 		link truncate quota quotacheck quotaon vgremove chgrp du fgrep \
-		pgrep tar rev kill fdformat ldd free losetup \
+		pgrep pkill tar rev kill fdformat ldd free losetup chown sed \
+		cat lsmod ip ping tc \
 		${LTP_DIR}/bin/* ${LTP_DIR}/testcases/bin/*" \
 	--include "$RAPIDO_DIR/autorun/ltp.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \


### PR DESCRIPTION
cat chown ip lsmod ping pkill sed tc

These are dependencies for LTP shell API and network tests
(some rarely used dependencies are omitted).

Signed-off-by: Petr Vorel <pvorel@suse.cz>