### PR TITLE
vm_autorun.env: add function to create /etc/hosts file #106

### DIFF
--- a/autorun/fstests_btrfs.sh
+++ b/autorun/fstests_btrfs.sh
@@ -23,14 +23,9 @@ set -x
 
 [ -n "$BTRFS_PROGS_SRC" ] && export PATH="${PATH}:${BTRFS_PROGS_SRC}"
 
-hostname_fqn="`cat /proc/sys/kernel/hostname`" || _fatal "hostname unavailable"
-hostname_short="${hostname_fqn%%.*}"
-filesystem="btrfs"
+_vm_ar_hosts_create
 
-# need hosts file for hostname -s
-cat > /etc/hosts <<EOF
-127.0.0.1	$hostname_fqn	$hostname_short
-EOF
+filesystem="btrfs"
 
 # use a 4-dev scratch pool for btrfs
 num_devs="5"

--- a/autorun/fstests_cephfs.sh
+++ b/autorun/fstests_cephfs.sh
@@ -22,14 +22,7 @@ fi
 
 set -x
 
-hostname_fqn="`cat /proc/sys/kernel/hostname`" || _fatal "hostname unavailable"
-hostname_short="${hostname_fqn%%.*}"
-
-# need hosts file for hostname -s
-cat > /etc/hosts <<EOF
-127.0.0.1	$hostname_fqn	$hostname_short
-EOF
-
+_vm_ar_hosts_create
 _vm_ar_dyn_debug_enable
 
 mkdir -p /mnt/test

--- a/autorun/fstests_cifs.sh
+++ b/autorun/fstests_cifs.sh
@@ -21,14 +21,7 @@ fi
 
 set -x
 
-hostname_fqn="`cat /proc/sys/kernel/hostname`" || _fatal "hostname unavailable"
-hostname_short="${hostname_fqn%%.*}"
-
-# need hosts file for hostname -s
-cat > /etc/hosts <<EOF
-127.0.0.1	$hostname_fqn	$hostname_short
-EOF
-
+_vm_ar_hosts_create
 _vm_ar_dyn_debug_enable
 
 set +x

--- a/autorun/fstests_xfs.sh
+++ b/autorun/fstests_xfs.sh
@@ -21,17 +21,9 @@ fi
 
 set -x
 
-hostname_fqn="`cat /proc/sys/kernel/hostname`" || _fatal "hostname unavailable"
-hostname_short="${hostname_fqn%%.*}"
-filesystem="xfs"
-
-# need hosts file for hostname -s
-cat > /etc/hosts <<EOF
-127.0.0.1	$hostname_fqn	$hostname_short
-EOF
-
 modprobe zram num_devices="2" || _fatal "failed to load zram module"
 
+_vm_ar_hosts_create
 _vm_ar_dyn_debug_enable
 
 echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -24,6 +24,24 @@ function _fatal() {
 	sleep 2
 }
 
+# create /etc/hosts file with the essential IPv4 and IPv6 lines
+function _vm_ar_hosts_create
+{
+	local hostname_fqn="`cat /proc/sys/kernel/hostname`" \
+		|| _fatal "hostname unavailable"
+	local hostname_short="${hostname_fqn%%.*}"
+
+	# need hosts file for hostname -s
+	cat > /etc/hosts <<EOF
+127.0.0.1	localhost
+127.0.1.1	$hostname_fqn	$hostname_short
+
+::1		localhost ip6-localhost ip6-loopback
+ff02::1		ip6-allnodes
+ff02::2		ip6-allrouters
+EOF
+}
+
 # set a kcli_$param variable based on the presence of $param[=$value] in
 # /proc/cmdline. Dots '.' in $param will be replaced in the variable with '_'.
 # If $param is present but doesn't have an "=$value" component, then


### PR DESCRIPTION
This PR fixes issue #106 . Here's the commit changelog:

Several autorun scripts were creating /etc/hosts.  Add a common function
for doing that.  While there, create this file following the
recommendations from hosts(5), namely:

 - use 127.0.0.1 for localhost
 - use 127.0.1.1 for the FQDN
 - add IPv6 entries

Signed-off-by: Luis Henriques <lhenriques@suse.com>