### PR TITLE
Allow usage of rapido in a VM running in VirtualBox

### DIFF
--- a/autorun/fstests_btrfs.sh
+++ b/autorun/fstests_btrfs.sh
@@ -32,8 +32,8 @@ cat > /etc/hosts <<EOF
 127.0.0.1	$hostname_fqn	$hostname_short
 EOF
 
-# use a 4-dev scratch pool for btrfs
-num_devs="5"
+# use a 5-dev scratch pool for btrfs
+num_devs="6"
 modprobe zram num_devices="${num_devs}" || _fatal "failed to load zram module"
 
 _vm_ar_dyn_debug_enable
@@ -59,7 +59,7 @@ MODULAR=0
 TEST_DIR=/mnt/test
 TEST_DEV=/dev/zram0
 SCRATCH_MNT=/mnt/scratch
-SCRATCH_DEV_POOL="/dev/zram1 /dev/zram2 /dev/zram3 /dev/zram4"
+SCRATCH_DEV_POOL="/dev/zram1 /dev/zram2 /dev/zram3 /dev/zram4 /dev/zram5"
 EOF
 
 set +x

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -29,7 +29,7 @@ _rt_require_btrfs_progs
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
 		   repquota setquota quotacheck quotaon pvremove vgremove \
-		   xfs_mkfile xfs_db xfs_io \
+		   xfs_mkfile xfs_db xfs_io wipefs \
 		   chgrp du fgrep pgrep tar rev kill duperemove \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \

--- a/runtime.vars
+++ b/runtime.vars
@@ -208,15 +208,21 @@ function _rt_require_dracut_args() {
 	DRACUT_EXTRA_ARGS="$DRACUT_EXTRA_ARGS $dracut_args"
 }
 
-function _rt_require_qemu_kvm_bin {
-	QEMU_KVM_BIN="$(which qemu-kvm 2>/dev/null)"
+function _rt_require_qemu {
+	QEMU_BIN="$(which qemu-system-x86_64)"
 
-	if [ -z "$QEMU_KVM_BIN" ]; then
+	[ -z "$QEMU_BIN" ] && _fail "missing qemu-system-x86_64"
+}
+
+function _rt_require_qemu_kvm_bin {
+	QEMU_BIN="$(which qemu-kvm 2>/dev/null)"
+
+	if [ -z "$QEMU_BIN" ]; then
 		# Debian uses kvm instead of qemu-kvm
-		QEMU_KVM_BIN="$(which kvm 2>/dev/null)"
+		QEMU_BIN="$(which kvm 2>/dev/null)"
 	fi
 
-	[ -z "$QEMU_KVM_BIN" ] && _fail "missing qemu-kvm"
+	[ -z "$QEMU_BIN" ] && _fail "missing qemu-kvm"
 }
 
 function _rt_require_lib()

--- a/vm.sh
+++ b/vm.sh
@@ -15,7 +15,11 @@
 RAPIDO_DIR="`dirname $0`"
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_qemu_kvm_bin
+if lsmod | grep -q vboxguest ; then
+	_rt_require_qemu
+else
+	_rt_require_qemu_kvm_bin
+fi
 
 function _vm_is_running
 {
@@ -86,7 +90,7 @@ function _vm_start
 	[ -f "$kernel_img" ] \
 	   || _fail "no kernel image present at ${kernel_img}. Build needed?"
 
-	$QEMU_KVM_BIN \
+	$QEMU_BIN \
 		$vm_resources \
 		-kernel "$kernel_img" \
 		-initrd "$DRACUT_OUT" \


### PR DESCRIPTION
Allow usage of rapido inside a  in a VM running in VirtualBox.

This contains a stale change for fstests-btrfs as well which should have been in a different PR but should be ok here as well.