### PR TITLE
add self test coverage

### DIFF
--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -47,6 +47,10 @@ TAP_USER=""
 # e.g. QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci -gdb tcp:127.0.0.1:1234"
 QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 
+# extra kernel boot parameters, passed via QEMU -append
+# e.g. QEMU_EXTRA_KERNEL_PARAMS="loglevel=0"
+#QEMU_EXTRA_KERNEL_PARAMS=""
+
 # extra dracut args, e.g. "--debug"
 #DRACUT_EXTRA_ARGS=""
 

--- a/selftest/selftest.sh
+++ b/selftest/selftest.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LLC 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+
+TD="$(mktemp -d rapido-selftest.XXXXXXX)"
+CLEANUP="rm -f ${TD}/*; rmdir $TD"
+# cleanup tmp dir when done
+trap "$CLEANUP" 0 1 2 3 15
+
+_usage() {
+	echo -e "usage:\n"
+		"\tKERNEL_SRC=/path/to/kernel/ " \
+		"KERNEL_INSTALL_MOD_PATH=/path/to/kernel/mods selftest.sh [test_filter]"
+	exit 1
+}
+
+_fail() {
+	echo "error: $*"
+	exit 1
+}
+
+_generate_conf() {
+	local conf="$1"
+	local example_conf="${RAPIDO_DIR}/rapido.conf.example"
+	local i sed_regexp
+
+	[ -f "$conf" ] && _fail "$conf already exists, aborting"
+
+	cp "$example_conf" "$conf" || _fail "cp failed"
+	echo "# Rapido selftest changes..." >> "$conf"
+
+	for i in KERNEL_SRC KERNEL_INSTALL_MOD_PATH; do
+		eval "val=\${$i}"
+		[ -n "$val" ] || _fail "$i is not set"
+		[ -d "$val" ] || _fail "$i is not a directory"
+
+		echo "${i}=\"${val}\"" >> "$conf" || _fail "write failed"
+	done
+
+	# set QEMU_EXTRA_KERNEL_PARAMS= so that printk doesn't go to console
+	echo "QEMU_EXTRA_KERNEL_PARAMS=\"loglevel=0\"" >> "$conf" \
+		|| _fail "write failed"
+	echo "QEMU_EXTRA_ARGS=\"-monitor none -serial stdio -nographic -device virtio-rng-pci\"" \
+		>> "$conf" || _fail "write failed"
+}
+
+_run_tests() {
+	local td="$1"
+	local filter="$2"
+	local tnum=0
+	local t
+
+	for t in $(ls "selftest/test/"${filter}); do
+		if ! [ -x "${t}" ]; then
+			echo "$t skipped"
+			continue
+		fi
+		echo "$t running"
+		${t} || _fail "test $t failed with $?"
+		(( tnum++ ))
+	done
+
+	echo "All $tnum tests passed"
+}
+
+[ -f "${RAPIDO_DIR}/rapido.conf" ] \
+	&& _fail "refusing to run with existing rapido.conf"
+
+FILTER="$1"
+if [ -n "$FILTER" ]; then
+	[ "$FILTER" == "${FILTER#*/}" ] || _fail "filter can't include /"
+	[ "$FILTER" == "${FILTER#*.}" ] || _fail "filter can't include ."
+else
+	FILTER="???"	# match all three digit tests by default
+fi
+
+# QEMU_EXTRA_X are explicitly set during selftest
+[ -z "$QEMU_EXTRA_ARGS" ] || _fail "QEMU_EXTRA_ARGS is set"
+[ -z "$QEMU_EXTRA_KERNEL_PARAMS" ] || _fail "QEMU_EXTRA_KERNEL_PARAMS is set"
+
+_generate_conf "${TD}/rapido.conf"
+
+ln -s ${TD}/rapido.conf "${RAPIDO_DIR}/rapido.conf" \
+	|| _fail "failed to link config"
+CLEANUP="${CLEANUP}; rm -f ${RAPIDO_DIR}/rapido.conf"
+
+pushd "${RAPIDO_DIR}"
+
+_run_tests "$TD" "$FILTER"
+
+popd

--- a/selftest/test/001
+++ b/selftest/test/001
@@ -1,0 +1,22 @@
+#!/usr/bin/expect -f
+#
+# Copyright (C) SUSE LLC 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+# cut+boot the simple-example runner and wait for the greeting string
+
+set timeout 60
+spawn ./rapido cut simple-example
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}

--- a/selftest/test/002
+++ b/selftest/test/002
@@ -1,0 +1,44 @@
+#!/usr/bin/expect -f
+#
+# Copyright (C) SUSE LLC 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+# simple-example runner with separate cut + boot invocations
+
+set timeout 60
+spawn ./rapido cut -B simple-example
+expect {
+	timeout {exit 1}
+	"dracut: *** Creating initramfs image file"
+}
+expect {
+	timeout {exit 1}
+	eof
+}
+spawn ./rapido boot
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}
+send "reboot\r"
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}
+send "cd root\r"
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"/root"
+}
+send "shutdown\r"
+expect eof {exit 0}
+exit 5

--- a/selftest/test/003
+++ b/selftest/test/003
@@ -1,0 +1,74 @@
+#!/usr/bin/expect -f
+#
+# Copyright (C) SUSE LLC 2019, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+# boot two simple-example runners in parallel and check hostnames
+
+set timeout 60
+spawn ./rapido cut -B simple-example
+expect {
+	timeout {exit 1}
+	eof
+}
+
+# boot first vm and wait for welcome
+spawn ./rapido boot
+set r1_sid $spawn_id
+
+expect {
+	-i $r1_sid
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}
+
+# check that first vm has been assigned vm_num=1
+send -i $r1_sid "cat /proc/cmdline\r"
+expect {
+	-i $r1_sid
+	timeout {exit 1}; eof {exit 2}
+	"rapido.vm_num=1"
+}
+
+# boot second vm and wait for welcome
+spawn ./rapido boot
+set r2_sid $spawn_id
+
+expect {
+	-i $r2_sid
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}
+
+# check that second vm has been assigned vm_num=2
+send -i $r2_sid "cat /proc/cmdline\r"
+expect {
+	-i $r2_sid
+	timeout {exit 1}; eof {exit 2}
+	"rapido.vm_num=2"
+}
+
+# shutdown first vm and wait for eof
+send -i $r1_sid "shutdown\r"
+expect {
+	-i $r1_sid
+	timeout {exit 1}
+	eof
+}
+
+# shutdown second vm and wait for eof
+send -i $r2_sid "shutdown\r"
+expect {
+	-i $r2_sid
+	timeout {exit 1}
+	eof
+}

--- a/vm.sh
+++ b/vm.sh
@@ -89,7 +89,8 @@ function _vm_start
 		-initrd "$DRACUT_OUT" \
 		-append "rapido.vm_num=${vm_num} ip=${kern_ip_addr} \
 			 rd.systemd.unit=emergency \
-		         rd.shell=1 console=$QEMU_KERNEL_CONSOLE rd.lvm=0 rd.luks=0" \
+		         rd.shell=1 console=$QEMU_KERNEL_CONSOLE rd.lvm=0 rd.luks=0 \
+			 $QEMU_EXTRA_KERNEL_PARAMS" \
 		-pidfile "$vm_pid_file" \
 		$virtfs_share \
 		$qemu_more_args


### PR DESCRIPTION
selftest/selftest.sh runs a quick check to ensure that rapido can cut and boot the simple-example image.