### PR TITLE
Nvme

### DIFF
--- a/autorun/blktests_zram.sh
+++ b/autorun/blktests_zram.sh
@@ -28,6 +28,7 @@ BLKTESTS_DIR="/blktests"
 modprobe zram num_devices="1" || _fatal "failed to load zram module"
 
 _vm_ar_dyn_debug_enable
+_vm_ar_configfs_mount
 
 echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"
 

--- a/cut/blktests_zram.sh
+++ b/cut/blktests_zram.sh
@@ -23,12 +23,12 @@ _rt_require_blktests
 		   lsblk strace which awk bc touch cut chmod true false mktemp \
 		   killall id sort uniq date expr tac diff head dirname seq \
 		   basename tee egrep hexdump sync fio logger cmp stat nproc \
-		   xfs_io modinfo blkdiscard realpath timeout" \
+		   xfs_io modinfo blkdiscard realpath timeout nvme" \
 	--include "$BLKTESTS_SRC" "/blktests" \
 	--include "$RAPIDO_DIR/autorun/blktests_zram.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
-	--add-drivers "zram lzo lzo-rle scsi_debug null_blk loop" \
+	--add-drivers "zram lzo lzo-rle scsi_debug null_blk loop nvme nvme-loop" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"


### PR DESCRIPTION
In order to run  blktests on nvmet there additional dependencies needed. This series adds the missing pieces to run the blktests on a nvmet loopback.