### PR TITLE
rapdio: make the size of the zram disks configurable

### DIFF
--- a/autorun/fstests_btrfs.sh
+++ b/autorun/fstests_btrfs.sh
@@ -33,8 +33,10 @@ modprobe zram num_devices="${num_devs}" || _fatal "failed to load zram module"
 
 _vm_ar_dyn_debug_enable
 
+[ -n "${FSTESTS_ZRAM_SIZE}" ] || FSTESTS_ZRAM_SIZE="1G"
+
 for i in $(seq 0 $((num_devs - 1))); do
-	echo "1G" > /sys/block/zram${i}/disksize \
+	echo "${FSTESTS_ZRAM_SIZE}" > /sys/block/zram${i}/disksize \
 		|| _fatal "failed to set zram disksize"
 done
 

--- a/autorun/fstests_xfs.sh
+++ b/autorun/fstests_xfs.sh
@@ -21,13 +21,18 @@ fi
 
 set -x
 
-modprobe zram num_devices="2" || _fatal "failed to load zram module"
+num_devs="2"
+modprobe zram num_devices="${num_devs}" || _fatal "failed to load zram module"
 
 _vm_ar_hosts_create
 _vm_ar_dyn_debug_enable
 
-echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"
-echo "1G" > /sys/block/zram1/disksize || _fatal "failed to set zram disksize"
+[ -n "${FSTESTS_ZRAM_SIZE}" ] || FSTESTS_ZRAM_SIZE="1G"
+
+for i in $(seq 0 $((num_devs - 1))); do
+	echo "${FSTESTS_ZRAM_SIZE}" > /sys/block/zram${i}/disksize \
+		|| _fatal "failed to set zram disksize"
+done
 
 mkdir -p /mnt/test
 mkdir -p /mnt/scratch

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -177,6 +177,8 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 # available at https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
 # e.g. FSTESTS_SRC="/home/me/xfstests-dev"
 #FSTESTS_SRC=""
+# e.g. FSTESTS_ZRAM_SIZE="2G"
+#FSTESTS_ZRAM_SIZE=""
 ##################################
 
 ####### autorun/blktests_*.sh #######


### PR DESCRIPTION
Make the size of the zram disks used for fstests configurable.

While we're at it, copy'n'paste the loop for setting the size from
fstests_btrfs.sh to fstests_xfs.sh as well to save some typing.

Signed-off-by: Johannes Thumshirn <jth@kernel.org>