### PR TITLE
cut/cephfs: drop CEPH_MOUNT_BIN helper binary

### DIFF
--- a/cut/cephfs.sh
+++ b/cut/cephfs.sh
@@ -22,16 +22,11 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_dracut_args
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace stat which touch cut chmod true false \
 		   getfattr setfattr getfacl setfacl killall sync \
-		   id sort uniq date expr tac diff head dirname seq ip ping \
-		   $LIBS_INSTALL_LIST" \
-	--include "$CEPH_MOUNT_BIN" "/sbin/mount.ceph" \
-	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
-	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
+		   id sort uniq date expr tac diff head dirname seq ip ping" \
 	--include "$RAPIDO_DIR/autorun/cephfs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -23,7 +23,6 @@ _rt_require_dracut_args
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_fstests
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs free \
@@ -39,12 +38,8 @@ _rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
 		   chgrp du fgrep pgrep tar rev kill ip ping \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/* \
-		   $LIBS_INSTALL_LIST" \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
-	--include "$CEPH_MOUNT_BIN" "/sbin/mount.ceph" \
-	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
-	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RAPIDO_DIR/autorun/fstests_cephfs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -23,7 +23,6 @@ _rt_require_dracut_args
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC
-_rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
 		   strace stat which touch cut chmod true false \
@@ -31,11 +30,7 @@ _rt_require_lib "libkeyutils.so.1 libhandle.so.1 libssl.so.1"
 		   id sort uniq date expr tac diff head dirname seq ip ping \
 		   ${SAMBA_SRC}/bin/smbpasswd \
 		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/smbd \
-		   $LIBS_INSTALL_LIST" \
-	--include "$CEPH_MOUNT_BIN" "/sbin/mount.ceph" \
-	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
-	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
+		   ${SAMBA_SRC}/bin/smbd" \
 	--include "$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh" "/.profile" \
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \


### PR DESCRIPTION
It's not needed, and has a bunch of dependencies. ceph.conf and the
keyring can also be removed thanks to _rt_write_ceph_config().

Signed-off-by: David Disseldorp <ddiss@suse.de>