### PR TITLE
tools/zram_hot_add: only add a single device

### DIFF
--- a/tools/zram_hot_add.sh
+++ b/tools/zram_hot_add.sh
@@ -37,7 +37,7 @@ function _usage()
 	exit 1
 }
 
-modprobe zram
+modprobe zram num_devices=0
 [ -e /sys/class/zram-control/hot_add ] \
 	|| _fail "zram hot_add sysfs path missing (old kernel?)"
 


### PR DESCRIPTION
If called before the zram module is loaded, two zram devices appear.
This is due to the default num_devices=1 probe behaviour and
unconditional sysfs zram-control/hot_add use.

Signed-off-by: David Disseldorp <ddiss@suse.de>