### PR TITLE
rapdio: add xxhash_generic module to btrfs initrd

### DIFF
--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -41,7 +41,7 @@ _rt_require_btrfs_progs
 	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
-		       loop scsi_debug dm-log-writes" \
+		       loop scsi_debug dm-log-writes xxhash_generic" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"


### PR DESCRIPTION
Since kernel v5.5 btrfs can use xxhash64 and sha256 as checksum hashes,
but we don't add the xxhash_generic driver to rapdio's initrd.

Add xxhash_generic to initrd, sha256 isn't needed as the rapido kernel
config has sha256 built in.

Signed-off-by: Johannes Thumshirn <johannes.thumshirn@wdc.com>