### PR TITLE
runtime.vars: drop dracut --list-modules sanity check

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -193,8 +193,6 @@ _rt_require_dracut_args() {
 	else
 		DRACUT="dracut"
 	fi
-	$DRACUT --list-modules &>/dev/null \
-		|| _fail "cannot run $DRACUT"
 
 	# The optional KERNEL_INSTALL_MOD_PATH rapido.conf parameter can be used
 	# to specify where Dracut should try to pull built kernel modules from.


### PR DESCRIPTION
On my system this costs ~200ms every "cut" invocation. It's unnecessary,
as dracut invocation failures will be caught when we actually generate
the initramfs image.

Signed-off-by: David Disseldorp <ddiss@suse.de>