### PR TITLE
rapido: remove existing image instead of using dracut --force

### DIFF
--- a/rapido
+++ b/rapido
@@ -84,6 +84,7 @@ rapido_cut()
 		exit
 	fi
 
+	rm -f "${RAPIDO_DIR}/initrds/myinitrd"
 	./$cut_script
 	local cut_status=$?
 	popd > /dev/null

--- a/runtime.vars
+++ b/runtime.vars
@@ -184,7 +184,7 @@ _rt_require_dracut_args() {
 	# --confdir sees Dracut use rapido specific configuration, instead of
 	# processing /etc/dracut.conf.d/*.conf
 	local dracut_args="--confdir ${RAPIDO_DIR}/dracut.conf.d \
-			   --force --tmpdir ${RAPIDO_DIR}/initrds/ \
+			   --tmpdir ${RAPIDO_DIR}/initrds/ \
 			   --kver $kver"
 
 	if [ -n "$DRACUT_SRC" ]; then


### PR DESCRIPTION
Until now we've used "dracut --force" to overwrite any existing rapido
initramfs images. However, this means that existing xattrs on the
overwritten image (used to track rapido VM resources, etc.) are retained
for the new image.
To avoid retaining stale xattrs, remove any existing image before
invoking Dracut, which can now be done without the --force parameter.

Link: https://github.com/rapido-linux/rapido/issues/132
Signed-off-by: David Disseldorp <ddiss@suse.de>