### PR TITLE
rapdio: add environment for zonefs tests over SCSI

### DIFF
--- a/autorun/zonefstests_scsi.sh
+++ b/autorun/zonefstests_scsi.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Western Digital Corporation, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+if [ ! -f /vm_autorun.env ]; then
+	echo "Error: autorun scripts must be run from within an initramfs VM"
+	exit 1
+fi
+
+. /vm_autorun.env
+
+set -x
+
+export PATH="${ZONEFSTOOLS_SRC}/src/:${PATH}"
+
+# path to zonefs-tests within the initramfs
+ZONEFSTESTS_DIR="/zonefs-tests"
+[ -d "$ZONEFSTESTS_DIR" ] || _fatal "zonefs-tests missing"
+
+modprobe scsi_debug zbc=host-managed zone_size_mb=64 virtual_gb=4 \
+	sector_size=4096 zone_nr_conv=3
+
+for dev_sysfs in /sys/block/*; do
+	if [ ! -f $dev_sysfs/device/model ]; then
+		continue
+	fi
+
+
+	model=$(cat $dev_sysfs/device/model)
+
+	if [ x$model == "xscsi_debug" ]; then
+		dev=${dev_sysfs/\/sys\/block\//}
+		break
+	fi
+
+done
+
+_vm_ar_dyn_debug_enable
+
+# create the zonefs null_blk device.
+
+mkzonefs -f /dev/$dev
+
+set +x
+
+echo "/dev/$dev provisioned and ready for zonefs-tests"
+
+if [ -n "$ZONEFSTESTS_AUTORUN_CMD" ]; then
+	cd ${ZONEFSTESTS_DIR} || _fatal
+	eval "$ZONEFSTESTS_AUTORUN_CMD"
+fi

--- a/cut/zonefstests_scsi.sh
+++ b/cut/zonefstests_scsi.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Western Digital Corporation, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args
+_rt_require_conf_dir ZONEFSTOOLS_SRC
+
+"$DRACUT" \
+	--install "ps rmdir dd id basename stat wc grep blkzone cut fio \
+		   rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
+	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
+	--include "$RAPIDO_DIR/autorun/zonefstests_scsi.sh" "/.profile" \
+	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
+	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	--add-drivers "scsi_debug zonefs" \
+	--modules "bash base" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+_rt_xattr_vm_networkless_set "$DRACUT_OUT"
+
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "2048M"


### PR DESCRIPTION
Now that the kernel' scsi_debug driver can emulate zoned block devices, we
can add environment for zonefs tests over SCSI.

This way we also have regression tests for SCSI only callpaths zonefs will
take, like the emulation of the ZONE APPEND commands in the SCSI layer.

Signed-off-by: Johannes Thumshirn <johannes.thumshirn@wdc.com>