### PR TITLE
Use dracut emergency hook

### DIFF
--- a/autorun/00-rapido-init.sh
+++ b/autorun/00-rapido-init.sh
@@ -14,8 +14,6 @@
 # This script runs as the first Dracut entry point during /init.
 # $DRACUT_SYSTEMD is set when run via systemd.
 
-echo "Rapido: starting autorun script..."
-
 _ctty=
 for i in $(cat /proc/cmdline); do
 	case "$i" in

--- a/autorun/00-rapido-init.sh
+++ b/autorun/00-rapido-init.sh
@@ -1,0 +1,33 @@
+#
+# Copyright (C) SUSE LLC 2020, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+# This script runs as the first Dracut entry point during /init.
+# $DRACUT_SYSTEMD is set when run via systemd.
+
+echo "Rapido: starting autorun script..."
+
+_ctty=
+for i in $(cat /proc/cmdline); do
+	case "$i" in
+		"console="*)
+			_ctty="/dev/${i#console=}"
+			break
+			;;
+	esac
+done
+[ -c "$_ctty" ] || _ctty=/dev/tty1
+setsid --ctty /bin/sh -i -l 0<>$_ctty 1<>$_ctty 2<>$_ctty
+
+# shut down when rapido autorun / shell exits...
+echo 1 > /proc/sys/kernel/sysrq && echo o > /proc/sysrq-trigger
+sleep 20

--- a/autorun/blktests_rbd.sh
+++ b/autorun/blktests_rbd.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 # path to blktests within the initramfs

--- a/autorun/blktests_rbd.sh
+++ b/autorun/blktests_rbd.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/blktests_rbd.sh
+++ b/autorun/blktests_rbd.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/blktests_zram.sh
+++ b/autorun/blktests_zram.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/blktests_zram.sh
+++ b/autorun/blktests_zram.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 # path to blktests within the initramfs

--- a/autorun/cephfs.sh
+++ b/autorun/cephfs.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/cephfs.sh
+++ b/autorun/cephfs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/cephfs.sh
+++ b/autorun/cephfs.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 _vm_ar_dyn_debug_enable

--- a/autorun/cephfs_fuse.sh
+++ b/autorun/cephfs_fuse.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 modprobe fuse

--- a/autorun/cephfs_fuse.sh
+++ b/autorun/cephfs_fuse.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/cephfs_fuse.sh
+++ b/autorun/cephfs_fuse.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/cifs.sh
+++ b/autorun/cifs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 _vm_ar_dyn_debug_enable
 

--- a/autorun/cifs.sh
+++ b/autorun/cifs.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 _vm_ar_dyn_debug_enable
 
 creds_path="/tmp/cifs_creds"

--- a/autorun/ctdb_cephfs.sh
+++ b/autorun/ctdb_cephfs.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 _vm_ar_dyn_debug_enable

--- a/autorun/ctdb_cephfs.sh
+++ b/autorun/ctdb_cephfs.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 _vm_ar_dyn_debug_enable
 
 export PATH="${SAMBA_SRC}/bin/:${PATH}"

--- a/autorun/ctdb_cephfs.sh
+++ b/autorun/ctdb_cephfs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/dropbear.sh
+++ b/autorun/dropbear.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 # block ssh client shells from triggering the dracut autorun script
 if [ -n "$SSH_CLIENT" ]; then
 	export PS1="dropbear:\${PWD}# "

--- a/autorun/dropbear.sh
+++ b/autorun/dropbear.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 # block ssh client shells from triggering the dracut autorun script
 if [ -n "$SSH_CLIENT" ]; then

--- a/autorun/fcoe_local.sh
+++ b/autorun/fcoe_local.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/fcoe_local.sh
+++ b/autorun/fcoe_local.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 #### start udevd

--- a/autorun/fstests_btrfs.sh
+++ b/autorun/fstests_btrfs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/fstests_btrfs.sh
+++ b/autorun/fstests_btrfs.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 [ -n "$BTRFS_PROGS_SRC" ] && export PATH="${PATH}:${BTRFS_PROGS_SRC}"

--- a/autorun/fstests_cephfs.sh
+++ b/autorun/fstests_cephfs.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/fstests_cephfs.sh
+++ b/autorun/fstests_cephfs.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 _vm_ar_hosts_create

--- a/autorun/fstests_cephfs.sh
+++ b/autorun/fstests_cephfs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/fstests_cifs.sh
+++ b/autorun/fstests_cifs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/fstests_cifs.sh
+++ b/autorun/fstests_cifs.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 _vm_ar_hosts_create

--- a/autorun/fstests_xfs.sh
+++ b/autorun/fstests_xfs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/fstests_xfs.sh
+++ b/autorun/fstests_xfs.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 num_devs="2"

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -19,8 +19,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 # start udevd

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -14,10 +14,7 @@
 
 export_blockdevs="/dev/vda /dev/vdb"
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/lio_pscsi_loop.sh
+++ b/autorun/lio_pscsi_loop.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/lio_pscsi_loop.sh
+++ b/autorun/lio_pscsi_loop.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 lio_cfgfs="/sys/kernel/config/target/"

--- a/autorun/lio_rbd.sh
+++ b/autorun/lio_rbd.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/lio_rbd.sh
+++ b/autorun/lio_rbd.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/lio_rbd.sh
+++ b/autorun/lio_rbd.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 # map rbd device

--- a/autorun/lrbd.sh
+++ b/autorun/lrbd.sh
@@ -15,10 +15,7 @@
 # autorun scripts are run immediately once the Rapido scratch VM has booted...
 
 # protect against running (harmful) scripts outside of Rapido VMs
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 # explitly load LIO core only, see dbroot comment below...
 modprobe target_core_mod

--- a/autorun/lrbd.sh
+++ b/autorun/lrbd.sh
@@ -20,8 +20,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 # explitly load LIO core only, see dbroot comment below...
 modprobe target_core_mod
 

--- a/autorun/ltp.sh
+++ b/autorun/ltp.sh
@@ -18,8 +18,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 _vm_ar_dyn_debug_enable
 
 set -x

--- a/autorun/ltp.sh
+++ b/autorun/ltp.sh
@@ -13,10 +13,7 @@
 # License for more details.
 
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 _vm_ar_dyn_debug_enable
 

--- a/autorun/mpath_local.sh
+++ b/autorun/mpath_local.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/mpath_local.sh
+++ b/autorun/mpath_local.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 _vm_ar_dyn_debug_enable

--- a/autorun/nvme_local.sh
+++ b/autorun/nvme_local.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 function _zram_hot_add() {
 	[ -e /sys/class/zram-control/hot_add ] \
 		|| _fatal "zram hot_add sysfs path missing (old kernel?)"

--- a/autorun/nvme_local.sh
+++ b/autorun/nvme_local.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 function _zram_hot_add() {
 	[ -e /sys/class/zram-control/hot_add ] \

--- a/autorun/nvme_rbd.sh
+++ b/autorun/nvme_rbd.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/nvme_rbd.sh
+++ b/autorun/nvme_rbd.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/nvme_rbd.sh
+++ b/autorun/nvme_rbd.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 # map rbd device

--- a/autorun/nvme_rdma.sh
+++ b/autorun/nvme_rdma.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 function _zram_hot_add() {
 	[ -e /sys/class/zram-control/hot_add ] \
 		|| _fatal "zram hot_add sysfs path missing (old kernel?)"

--- a/autorun/nvme_rdma.sh
+++ b/autorun/nvme_rdma.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 function _zram_hot_add() {
 	[ -e /sys/class/zram-control/hot_add ] \

--- a/autorun/nvme_tcp_initiator.sh
+++ b/autorun/nvme_tcp_initiator.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/nvme_tcp_initiator.sh
+++ b/autorun/nvme_tcp_initiator.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 #### start udevd

--- a/autorun/nvme_tcp_rbd.sh
+++ b/autorun/nvme_tcp_rbd.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/nvme_tcp_rbd.sh
+++ b/autorun/nvme_tcp_rbd.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/nvme_tcp_rbd.sh
+++ b/autorun/nvme_tcp_rbd.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 # map rbd device

--- a/autorun/openiscsi.sh
+++ b/autorun/openiscsi.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/openiscsi.sh
+++ b/autorun/openiscsi.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 modprobe iscsi_tcp

--- a/autorun/rbd.sh
+++ b/autorun/rbd.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/rbd.sh
+++ b/autorun/rbd.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/rbd.sh
+++ b/autorun/rbd.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 # map rbd device

--- a/autorun/rbd_nbd.sh
+++ b/autorun/rbd_nbd.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \

--- a/autorun/rbd_nbd.sh
+++ b/autorun/rbd_nbd.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/rbd_nbd.sh
+++ b/autorun/rbd_nbd.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/samba_cephfs.sh
+++ b/autorun/samba_cephfs.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 export PATH="${SAMBA_SRC}/bin/:${PATH}"

--- a/autorun/samba_cephfs.sh
+++ b/autorun/samba_cephfs.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/samba_cephfs.sh
+++ b/autorun/samba_cephfs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -17,7 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
 . /vm_ceph.env || _fatal
 
 set -x

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 . /vm_ceph.env || _fatal
 

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -14,8 +14,6 @@
 
 _vm_ar_env_check || exit 1
 
-. /vm_ceph.env || _fatal
-
 set -x
 
 _vm_ar_dyn_debug_enable

--- a/autorun/samba_local.sh
+++ b/autorun/samba_local.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/samba_local.sh
+++ b/autorun/samba_local.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 filesystem="btrfs"

--- a/autorun/simple_example.sh
+++ b/autorun/simple_example.sh
@@ -12,15 +12,14 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-# autorun scripts are run immediately once the Rapido scratch VM has booted...
+# autorun scripts are run once the Rapido scratch VM has booted. The scripts
+# are sourced by vm_autorun.env and have access to rapido.conf variables.
 
 # protect against running (harmful) scripts outside of Rapido VMs
 if [ ! -f /vm_autorun.env ]; then
 	echo "Error: autorun scripts must be run from within an initramfs VM"
 	exit 1
 fi
-
-. /vm_autorun.env
 
 # echo shell commands as they are executed
 set -x

--- a/autorun/simple_example.sh
+++ b/autorun/simple_example.sh
@@ -16,10 +16,7 @@
 # are sourced by vm_autorun.env and have access to rapido.conf variables.
 
 # protect against running (harmful) scripts outside of Rapido VMs
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 # echo shell commands as they are executed
 set -x

--- a/autorun/tcmu_rbd_loop.sh
+++ b/autorun/tcmu_rbd_loop.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/tcmu_rbd_loop.sh
+++ b/autorun/tcmu_rbd_loop.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 lio_cfgfs="/sys/kernel/config/target/"

--- a/autorun/tgt_local.sh
+++ b/autorun/tgt_local.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/tgt_local.sh
+++ b/autorun/tgt_local.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 modprobe zram num_devices="1" || _fatal "failed to load zram module"

--- a/autorun/usb_rbd.sh
+++ b/autorun/usb_rbd.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/usb_rbd.sh
+++ b/autorun/usb_rbd.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 #### ddiss - start udevd, so that the rbdnamer hook is invoked

--- a/autorun/zonefstests_nullblk.sh
+++ b/autorun/zonefstests_nullblk.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 export PATH="${ZONEFSTOOLS_SRC}/src/:${PATH}"

--- a/autorun/zonefstests_nullblk.sh
+++ b/autorun/zonefstests_nullblk.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/autorun/zonefstests_scsi.sh
+++ b/autorun/zonefstests_scsi.sh
@@ -17,8 +17,6 @@ if [ ! -f /vm_autorun.env ]; then
 	exit 1
 fi
 
-. /vm_autorun.env
-
 set -x
 
 export PATH="${ZONEFSTOOLS_SRC}/src/:${PATH}"

--- a/autorun/zonefstests_scsi.sh
+++ b/autorun/zonefstests_scsi.sh
@@ -12,10 +12,7 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-if [ ! -f /vm_autorun.env ]; then
-	echo "Error: autorun scripts must be run from within an initramfs VM"
-	exit 1
-fi
+_vm_ar_env_check || exit 1
 
 set -x
 

--- a/cut/blktests_rbd.sh
+++ b/cut/blktests_rbd.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/blktests_rbd.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_blktests
@@ -35,7 +35,6 @@ _rt_require_blktests
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$BLKTESTS_SRC" "/blktests" \
-	--include "$RAPIDO_DIR/autorun/blktests_rbd.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "scsi_debug null_blk loop" \

--- a/cut/blktests_rbd.sh
+++ b/cut/blktests_rbd.sh
@@ -36,8 +36,7 @@ _rt_require_blktests
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$BLKTESTS_SRC" "/blktests" \
 	--include "$RAPIDO_DIR/autorun/blktests_rbd.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "scsi_debug null_blk loop" \
 	--modules "bash base" \

--- a/cut/blktests_rbd.sh
+++ b/cut/blktests_rbd.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/blktests_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/blktests_rbd.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_blktests
@@ -36,7 +36,6 @@ _rt_require_blktests
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$BLKTESTS_SRC" "/blktests" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "scsi_debug null_blk loop" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/blktests_zram.sh
+++ b/cut/blktests_zram.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/blktests_zram.sh"
 _rt_require_blktests
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -25,7 +25,6 @@ _rt_require_blktests
 		   basename tee egrep hexdump sync fio logger cmp stat nproc \
 		   xfs_io modinfo blkdiscard realpath timeout nvme" \
 	--include "$BLKTESTS_SRC" "/blktests" \
-	--include "$RAPIDO_DIR/autorun/blktests_zram.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle scsi_debug null_blk loop nvme nvme-loop" \
 	--modules "bash base" \

--- a/cut/blktests_zram.sh
+++ b/cut/blktests_zram.sh
@@ -26,8 +26,7 @@ _rt_require_blktests
 		   xfs_io modinfo blkdiscard realpath timeout nvme" \
 	--include "$BLKTESTS_SRC" "/blktests" \
 	--include "$RAPIDO_DIR/autorun/blktests_zram.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle scsi_debug null_blk loop nvme nvme-loop" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/cephfs.sh
+++ b/cut/cephfs.sh
@@ -21,14 +21,13 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs.sh"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace stat which touch cut chmod true false \
 		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq ip ping" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "ceph libceph" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/cephfs.sh
+++ b/cut/cephfs.sh
@@ -21,13 +21,12 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/cephfs.sh"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace stat which touch cut chmod true false \
 		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq ip ping" \
-	--include "$RAPIDO_DIR/autorun/cephfs.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "ceph libceph" \

--- a/cut/cephfs.sh
+++ b/cut/cephfs.sh
@@ -28,8 +28,7 @@ _rt_require_dracut_args
 		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq ip ping" \
 	--include "$RAPIDO_DIR/autorun/cephfs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "ceph libceph" \
 	--modules "bash base" \

--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -22,7 +22,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_write_ceph_bin_paths $vm_ceph_conf
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/cephfs_fuse.sh"
 _rt_require_lib "libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
@@ -33,7 +33,6 @@ _rt_require_lib "libsoftokn3.so \
 		   $LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
-	--include "$RAPIDO_DIR/autorun/cephfs_fuse.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "fuse" \

--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -22,7 +22,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_write_ceph_bin_paths $vm_ceph_conf
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/cephfs_fuse.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs_fuse.sh"
 _rt_require_lib "libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
@@ -34,7 +34,6 @@ _rt_require_lib "libsoftokn3.so \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "fuse" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -34,8 +34,7 @@ _rt_require_lib "libsoftokn3.so \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RAPIDO_DIR/autorun/cephfs_fuse.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "fuse" \
 	--modules "bash base" \

--- a/cut/cifs.sh
+++ b/cut/cifs.sh
@@ -15,14 +15,13 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/cifs.sh"
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
 		   mount.cifs ip ping getfacl setfacl truncate du \
 		   which touch cut chmod true false unlink \
 		   getfattr setfattr chacl attr killall sync \
 		   dirname seq basename fstrim chattr lsattr stat" \
-	--include "$RAPIDO_DIR/autorun/cifs.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm gcm ctr" \
 	--modules "bash base" \

--- a/cut/cifs.sh
+++ b/cut/cifs.sh
@@ -23,8 +23,7 @@ _rt_require_dracut_args
 		   getfattr setfattr chacl attr killall sync \
 		   dirname seq basename fstrim chattr lsattr stat" \
 	--include "$RAPIDO_DIR/autorun/cifs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm gcm ctr" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/ctdb_cephfs.sh
+++ b/cut/ctdb_cephfs.sh
@@ -22,7 +22,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_samba_ctdb
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/ctdb_cephfs.sh"
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
@@ -68,7 +68,6 @@ fi
 	--include "$CEPH_RADOS_LIB" "/usr/lib64/librados.so.2" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
-	--include "$RAPIDO_DIR/autorun/ctdb_cephfs.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--modules "bash base" \

--- a/cut/ctdb_cephfs.sh
+++ b/cut/ctdb_cephfs.sh
@@ -69,8 +69,7 @@ fi
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RAPIDO_DIR/autorun/ctdb_cephfs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/ctdb_cephfs.sh
+++ b/cut/ctdb_cephfs.sh
@@ -22,7 +22,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_samba_ctdb
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/ctdb_cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/ctdb_cephfs.sh"
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
@@ -69,7 +69,6 @@ fi
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/dropbear.sh
+++ b/cut/dropbear.sh
@@ -15,13 +15,12 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/dropbear.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs dropbear chmod ip ping \
 		   $LIBS_INSTALL_LIST" \
-	--include "$RAPIDO_DIR/autorun/dropbear.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/dropbear.sh
+++ b/cut/dropbear.sh
@@ -22,8 +22,7 @@ _rt_require_lib "libkeyutils.so.1"
 		   strace mkfs.xfs dropbear chmod ip ping \
 		   $LIBS_INSTALL_LIST" \
 	--include "$RAPIDO_DIR/autorun/dropbear.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/fcoe_local.sh
+++ b/cut/fcoe_local.sh
@@ -22,8 +22,7 @@ _rt_require_lib "libkeyutils.so.1"
 		   ip ping \
 		   $LIBS_INSTALL_LIST" \
 	--include "$RAPIDO_DIR/autorun/fcoe_local.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod tcm_fc target_core_iblock \
 			target_core_file libfc fcoe scsi_debug" \
 	--modules "bash base" \

--- a/cut/fcoe_local.sh
+++ b/cut/fcoe_local.sh
@@ -14,14 +14,13 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fcoe_local.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs killall truncate dirname fipvlan basename \
 		   ip ping \
 		   $LIBS_INSTALL_LIST" \
-	--include "$RAPIDO_DIR/autorun/fcoe_local.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod tcm_fc target_core_iblock \
 			target_core_file libfc fcoe scsi_debug" \

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -38,8 +38,7 @@ _rt_require_btrfs_progs
 		   $BTRFS_PROGS_BINS" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--include "$RAPIDO_DIR/autorun/fstests_btrfs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
 		       loop scsi_debug dm-log-writes xxhash_generic" \
 	--modules "bash base" \

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs.sh"
 _rt_require_fstests
 _rt_require_btrfs_progs
 
@@ -37,7 +37,6 @@ _rt_require_btrfs_progs
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*
 		   $BTRFS_PROGS_BINS" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
-	--include "$RAPIDO_DIR/autorun/fstests_btrfs.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
 		       loop scsi_debug dm-log-writes xxhash_generic" \

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/fstests_cephfs.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_fstests
@@ -41,7 +41,6 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -41,8 +41,7 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--include "$RAPIDO_DIR/autorun/fstests_cephfs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cephfs.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_fstests
@@ -40,7 +40,6 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
-	--include "$RAPIDO_DIR/autorun/fstests_cephfs.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--modules "bash base" \

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -35,8 +35,7 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--include "$RAPIDO_DIR/autorun/fstests_cifs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm ctr" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cifs.sh"
 _rt_require_fstests
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -34,7 +34,6 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
-	--include "$RAPIDO_DIR/autorun/fstests_cifs.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm ctr" \
 	--modules "bash base" \

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_xfs.sh"
 _rt_require_fstests
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -36,7 +36,6 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
-	--include "$RAPIDO_DIR/autorun/fstests_xfs.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey xfs" \
 	--modules "bash base" \

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -37,8 +37,7 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--include "$RAPIDO_DIR/autorun/fstests_xfs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey xfs" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/lio_local.sh
+++ b/cut/lio_local.sh
@@ -15,12 +15,11 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_local.sh"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs truncate losetup dmsetup \
 		   /usr/lib/udev/rules.d/95-dm-notify.rules ip ping" \
-	--include "$RAPIDO_DIR/autorun/lio_local.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_iblock \
 		       target_core_file dm-delay loop" \

--- a/cut/lio_local.sh
+++ b/cut/lio_local.sh
@@ -21,8 +21,7 @@ _rt_require_dracut_args
 		   strace mkfs.xfs truncate losetup dmsetup \
 		   /usr/lib/udev/rules.d/95-dm-notify.rules ip ping" \
 	--include "$RAPIDO_DIR/autorun/lio_local.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_iblock \
 		       target_core_file dm-delay loop" \
 	--modules "bash base" \

--- a/cut/lio_pscsi_loop.sh
+++ b/cut/lio_pscsi_loop.sh
@@ -26,8 +26,7 @@ _rt_require_dracut_args
 		   mkfs mkfs.xfs parted partprobe sgdisk hdparm uuidgen \
 		   env lsscsi awk" \
 	--include "${RAPIDO_DIR}/autorun/lio_pscsi_loop.sh" "/.profile" \
-	--include "${RAPIDO_DIR}/rapido.conf" "/rapido.conf" \
-	--include "${RAPIDO_DIR}/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi target_core_pscsi tcm_loop" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/lio_pscsi_loop.sh
+++ b/cut/lio_pscsi_loop.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/lio_pscsi_loop.sh"
 
 # the pscsi VM should be booted with a virtio SCSI device attached. E.g.
 # QEMU_EXTRA_ARGS="-nographic -device virtio-scsi-pci,id=scsi \
@@ -25,7 +25,6 @@ _rt_require_dracut_args
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   mkfs mkfs.xfs parted partprobe sgdisk hdparm uuidgen \
 		   env lsscsi awk" \
-	--include "${RAPIDO_DIR}/autorun/lio_pscsi_loop.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi target_core_pscsi tcm_loop" \
 	--modules "bash base" \

--- a/cut/lio_rbd.sh
+++ b/cut/lio_rbd.sh
@@ -32,8 +32,7 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$RAPIDO_DIR/autorun/lio_rbd.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \
 	--modules "bash base" \

--- a/cut/lio_rbd.sh
+++ b/cut/lio_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lio_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -32,7 +32,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/lio_rbd.sh
+++ b/cut/lio_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -31,7 +31,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
-	--include "$RAPIDO_DIR/autorun/lio_rbd.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \

--- a/cut/lrbd.sh
+++ b/cut/lrbd.sh
@@ -49,8 +49,7 @@ rados_cython="${CEPH_SRC}"/build/lib/cython_modules/lib.3/rados.cpython-34m.so
 	--include "$TARGETCLI_SRC" "/targetcli/" \
 	--include "$CONFIGSHELL_SRC" "/configshell/" \
 	--include "$RAPIDO_DIR/autorun/lrbd.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \
 	--modules "bash base systemd systemd-initrd dracut-systemd" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/lrbd.sh
+++ b/cut/lrbd.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lrbd.sh"
 _rt_require_ceph
 _rt_require_conf_dir LRBD_SRC TARGETCLI_SRC RTSLIB_SRC CONFIGSHELL_SRC
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
@@ -48,7 +48,6 @@ rados_cython="${CEPH_SRC}"/build/lib/cython_modules/lib.3/rados.cpython-34m.so
 	--include "$RTSLIB_SRC" "/rtslib/" \
 	--include "$TARGETCLI_SRC" "/targetcli/" \
 	--include "$CONFIGSHELL_SRC" "/configshell/" \
-	--include "$RAPIDO_DIR/autorun/lrbd.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \
 	--modules "bash base systemd systemd-initrd dracut-systemd" \

--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -29,8 +29,7 @@ _rt_require_conf_dir LTP_DIR
 		cat lsmod ip ping tc \
 		${LTP_DIR}/bin/* ${LTP_DIR}/testcases/bin/*" \
 	--include "$RAPIDO_DIR/autorun/ltp.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$LTP_DIR" "$LTP_DIR"  \
 	--add-drivers "loop" \
 	--modules "bash base" \

--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/ltp.sh"
 _rt_require_conf_dir LTP_DIR
 
 "$DRACUT" \
@@ -28,7 +28,6 @@ _rt_require_conf_dir LTP_DIR
 		pgrep pkill tar rev kill fdformat ldd free losetup chown sed \
 		cat lsmod ip ping tc \
 		${LTP_DIR}/bin/* ${LTP_DIR}/testcases/bin/*" \
-	--include "$RAPIDO_DIR/autorun/ltp.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$LTP_DIR" "$LTP_DIR"  \
 	--add-drivers "loop" \

--- a/cut/mpath_local.sh
+++ b/cut/mpath_local.sh
@@ -32,8 +32,7 @@ _rt_require_dracut_args
 		   strace mkfs mkfs.xfs parted partprobe sgdisk hdparm \
 		   timeout id chown chmod env killall getopt basename" \
 	--include "$RAPIDO_DIR/autorun/mpath_local.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi virtio_pci sd_mod" \
 	--modules "bash base systemd systemd-initrd dracut-systemd multipath" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/mpath_local.sh
+++ b/cut/mpath_local.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/mpath_local.sh"
 
 # the VM should be deployed with two virtio SCSI devices which share the same
 # backing <file> and <serial> parameters. E.g.
@@ -31,7 +31,6 @@ _rt_require_dracut_args
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs parted partprobe sgdisk hdparm \
 		   timeout id chown chmod env killall getopt basename" \
-	--include "$RAPIDO_DIR/autorun/mpath_local.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi virtio_pci sd_mod" \
 	--modules "bash base systemd systemd-initrd dracut-systemd multipath" \

--- a/cut/nvme_local.sh
+++ b/cut/nvme_local.sh
@@ -15,13 +15,12 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_local.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs \
 		   $LIBS_INSTALL_LIST" \
-	--include "$RAPIDO_DIR/autorun/nvme_local.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet zram lzo lzo-rle" \
 	--modules "bash base" \

--- a/cut/nvme_local.sh
+++ b/cut/nvme_local.sh
@@ -22,8 +22,7 @@ _rt_require_lib "libkeyutils.so.1"
 		   strace mkfs.xfs \
 		   $LIBS_INSTALL_LIST" \
 	--include "$RAPIDO_DIR/autorun/nvme_local.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet zram lzo lzo-rle" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/nvme_rbd.sh
+++ b/cut/nvme_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -31,7 +31,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
-	--include "$RAPIDO_DIR/autorun/nvme_rbd.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet" \

--- a/cut/nvme_rbd.sh
+++ b/cut/nvme_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -32,7 +32,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/nvme_rbd.sh
+++ b/cut/nvme_rbd.sh
@@ -32,8 +32,7 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$RAPIDO_DIR/autorun/nvme_rbd.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet" \
 	--modules "bash base" \

--- a/cut/nvme_rdma.sh
+++ b/cut/nvme_rdma.sh
@@ -22,8 +22,7 @@ _rt_require_lib "libkeyutils.so.1"
 		   strace mkfs.xfs killall nvme ip ping \
 		   $LIBS_INSTALL_LIST" \
 	--include "$RAPIDO_DIR/autorun/nvme_rdma.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \
 		       rdma_rxe zram lzo lzo-rle ib_core ib_uverbs rdma_ucm \
 		       crc32_generic" \

--- a/cut/nvme_rdma.sh
+++ b/cut/nvme_rdma.sh
@@ -15,13 +15,12 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rdma.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs killall nvme ip ping \
 		   $LIBS_INSTALL_LIST" \
-	--include "$RAPIDO_DIR/autorun/nvme_rdma.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \
 		       rdma_rxe zram lzo lzo-rle ib_core ib_uverbs rdma_ucm \

--- a/cut/nvme_tcp_initiator.sh
+++ b/cut/nvme_tcp_initiator.sh
@@ -15,11 +15,10 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_tcp_initiator.sh"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs ip ping" \
-	--include "$RAPIDO_DIR/autorun/nvme_tcp_initiator.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-tcp" \

--- a/cut/nvme_tcp_initiator.sh
+++ b/cut/nvme_tcp_initiator.sh
@@ -20,8 +20,7 @@ _rt_require_dracut_args
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs ip ping" \
 	--include "$RAPIDO_DIR/autorun/nvme_tcp_initiator.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-tcp" \
 	--modules "bash base" \

--- a/cut/nvme_tcp_rbd.sh
+++ b/cut/nvme_tcp_rbd.sh
@@ -32,8 +32,7 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvmet-tcp nvmet" \
 	--modules "bash base" \

--- a/cut/nvme_tcp_rbd.sh
+++ b/cut/nvme_tcp_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -31,7 +31,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
-	--include "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvmet-tcp nvmet" \

--- a/cut/nvme_tcp_rbd.sh
+++ b/cut/nvme_tcp_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -32,7 +32,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvmet-tcp nvmet" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/openiscsi.sh
+++ b/cut/openiscsi.sh
@@ -24,8 +24,7 @@ _rt_require_conf_dir OPENISCSI_SRC
 		   ${OPENISCSI_SRC}/libopeniscsiusr/libopeniscsiusr.so \
 		   ${OPENISCSI_SRC}/usr/iscsiadm" \
 	--include "${RAPIDO_DIR}/autorun/openiscsi.sh" "/.profile" \
-	--include "${RAPIDO_DIR}/rapido.conf" "/rapido.conf" \
-	--include "${RAPIDO_DIR}/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	--drivers "iscsi_tcp" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/openiscsi.sh
+++ b/cut/openiscsi.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/openiscsi.sh"
 _rt_require_conf_dir OPENISCSI_SRC
 
 "$DRACUT" \
@@ -23,7 +23,6 @@ _rt_require_conf_dir OPENISCSI_SRC
 		   ${OPENISCSI_SRC}/usr/iscsid \
 		   ${OPENISCSI_SRC}/libopeniscsiusr/libopeniscsiusr.so \
 		   ${OPENISCSI_SRC}/usr/iscsiadm" \
-	--include "${RAPIDO_DIR}/autorun/openiscsi.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	--drivers "iscsi_tcp" \

--- a/cut/qemu_rbd.sh
+++ b/cut/qemu_rbd.sh
@@ -22,8 +22,8 @@ _rt_require_lib "libkeyutils.so.1"
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs lsscsi \
 		   $LIBS_INSTALL_LIST" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
 	--include "$RAPIDO_DIR/vm_autorun.env" "/.profile" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/qemu_rbd.sh
+++ b/cut/qemu_rbd.sh
@@ -15,14 +15,13 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/vm_autorun.env"
 _rt_require_ceph
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs lsscsi \
 		   $LIBS_INSTALL_LIST" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/rbd.sh
+++ b/cut/rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -31,7 +31,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
-	--include "$RAPIDO_DIR/autorun/rbd.sh" "/.profile" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \

--- a/cut/rbd.sh
+++ b/cut/rbd.sh
@@ -32,9 +32,8 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$RAPIDO_DIR/autorun/rbd.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/rbd.sh
+++ b/cut/rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -31,7 +31,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/rbd_nbd.sh
+++ b/cut/rbd_nbd.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "${RAPIDO_DIR}/autorun/rbd_nbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/rbd_nbd.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_lib "libsoftokn3.so libsqlite3.so \
@@ -35,7 +35,6 @@ rbd_nbd_bin="${CEPH_SRC}/build/bin/rbd-nbd"
 		   $LIBS_INSTALL_LIST $rbd_nbd_bin" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nbd" \
 	--modules "bash base" \

--- a/cut/rbd_nbd.sh
+++ b/cut/rbd_nbd.sh
@@ -34,11 +34,10 @@ rbd_nbd_bin="${CEPH_SRC}/build/bin/rbd-nbd"
 		   strace mkfs.xfs mkfs.btrfs sync dirname uuidgen sleep ip ping \
 		   $LIBS_INSTALL_LIST $rbd_nbd_bin" \
 	--include "${RAPIDO_DIR}/autorun/rbd_nbd.sh" "/.profile" \
-	--include "${RAPIDO_DIR}/rapido.conf" "/rapido.conf" \
-	--include "${RAPIDO_DIR}/vm_autorun.env" "/vm_autorun.env" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nbd" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/rbd_nbd.sh
+++ b/cut/rbd_nbd.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/rbd_nbd.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_lib "libsoftokn3.so libsqlite3.so \
@@ -33,7 +33,6 @@ rbd_nbd_bin="${CEPH_SRC}/build/bin/rbd-nbd"
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs mkfs.btrfs sync dirname uuidgen sleep ip ping \
 		   $LIBS_INSTALL_LIST $rbd_nbd_bin" \
-	--include "${RAPIDO_DIR}/autorun/rbd_nbd.sh" "/.profile" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -41,9 +41,8 @@ _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RAPIDO_DIR/autorun/samba_cephfs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/samba_cephfs.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC
@@ -40,7 +40,6 @@ _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 	--include "$CEPH_RADOS_LIB" "/usr/lib64/librados.so.2" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_cephfs.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC
@@ -40,7 +40,6 @@ _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 	--include "$CEPH_RADOS_LIB" "/usr/lib64/librados.so.2" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
-	--include "$RAPIDO_DIR/autorun/samba_cephfs.sh" "/.profile" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -19,7 +19,8 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" \
+			"$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC
@@ -31,7 +32,6 @@ _rt_require_conf_dir SAMBA_SRC
 		   ${SAMBA_SRC}/bin/smbpasswd \
 		   ${SAMBA_SRC}/bin/smbstatus \
 		   ${SAMBA_SRC}/bin/smbd" \
-	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "ceph libceph" \
 	--modules "bash base" \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -32,9 +32,8 @@ _rt_require_conf_dir SAMBA_SRC
 		   ${SAMBA_SRC}/bin/smbstatus \
 		   ${SAMBA_SRC}/bin/smbd" \
 	--include "$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "ceph libceph" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC
@@ -31,7 +31,6 @@ _rt_require_conf_dir SAMBA_SRC
 		   ${SAMBA_SRC}/bin/smbpasswd \
 		   ${SAMBA_SRC}/bin/smbstatus \
 		   ${SAMBA_SRC}/bin/smbd" \
-	--include "$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh" "/.profile" \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "ceph libceph" \

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_local.sh"
 _rt_require_conf_dir SAMBA_SRC
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
@@ -27,7 +27,6 @@ _rt_require_conf_dir SAMBA_SRC
 		   ${SAMBA_SRC}/bin/smbstatus \
 		   ${SAMBA_SRC}/bin/modules/vfs/btrfs.so \
 		   ${SAMBA_SRC}/bin/smbd" \
-	--include "$RAPIDO_DIR/autorun/samba_local.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle xfs btrfs" \
 	--modules "bash base" \

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -28,8 +28,7 @@ _rt_require_conf_dir SAMBA_SRC
 		   ${SAMBA_SRC}/bin/modules/vfs/btrfs.so \
 		   ${SAMBA_SRC}/bin/smbd" \
 	--include "$RAPIDO_DIR/autorun/samba_local.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle xfs btrfs" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/simple_example.sh
+++ b/cut/simple_example.sh
@@ -37,8 +37,7 @@ _rt_require_dracut_args
 "$DRACUT" \
 	--install "ps rmdir dd mkfs.xfs" \
 	--include "$RAPIDO_DIR/autorun/simple_example.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/simple_example.sh
+++ b/cut/simple_example.sh
@@ -15,7 +15,9 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+# Call _rt_require_dracut_args() providing a script path that will be run on
+# VM boot. It exports variables used in the dracut invocation below.
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/simple_example.sh"
 
 # The job of Rapido cut scripts is to generate a VM image. This is done using
 # Dracut with the following parameters...
@@ -36,7 +38,6 @@ _rt_require_dracut_args
 # debugging, etc.
 "$DRACUT" \
 	--install "ps rmdir dd mkfs.xfs" \
-	--include "$RAPIDO_DIR/autorun/simple_example.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
 	--modules "bash base" \

--- a/cut/tcmu_rbd_loop.sh
+++ b/cut/tcmu_rbd_loop.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tcmu_rbd_loop.sh"
 _rt_require_conf_dir TCMU_RUNNER_SRC CEPH_SRC
 _rt_require_ceph
 # NSS_InitContext() fails without the following...
@@ -29,7 +29,6 @@ _rt_require_lib "libsoftokn3.so libfreeblpriv3.so"
 		   ${TCMU_RUNNER_SRC}/tcmu-runner \
 		   ${TCMU_RUNNER_SRC}/handler_rbd.so \
 		   $LIBS_INSTALL_LIST" \
-	--include "${RAPIDO_DIR}/autorun/tcmu_rbd_loop.sh" "/.profile" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \

--- a/cut/tcmu_rbd_loop.sh
+++ b/cut/tcmu_rbd_loop.sh
@@ -30,10 +30,9 @@ _rt_require_lib "libsoftokn3.so libfreeblpriv3.so"
 		   ${TCMU_RUNNER_SRC}/handler_rbd.so \
 		   $LIBS_INSTALL_LIST" \
 	--include "${RAPIDO_DIR}/autorun/tcmu_rbd_loop.sh" "/.profile" \
-	--include "${RAPIDO_DIR}/rapido.conf" "/rapido.conf" \
-	--include "${RAPIDO_DIR}/vm_autorun.env" "/vm_autorun.env" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod target_core_user tcm_loop" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/tgt_local.sh
+++ b/cut/tgt_local.sh
@@ -23,8 +23,7 @@ _rt_require_conf_dir TGT_SRC
 		   ${TGT_SRC}/usr/tgtd \
 		   ${TGT_SRC}/usr/tgtadm" \
 	--include "${RAPIDO_DIR}/autorun/tgt_local.sh" "/.profile" \
-	--include "${RAPIDO_DIR}/rapido.conf" "/rapido.conf" \
-	--include "${RAPIDO_DIR}/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/tgt_local.sh
+++ b/cut/tgt_local.sh
@@ -15,14 +15,13 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tgt_local.sh"
 _rt_require_conf_dir TGT_SRC
 
 "$DRACUT" \
 	--install "grep ps ip ping \
 		   ${TGT_SRC}/usr/tgtd \
 		   ${TGT_SRC}/usr/tgtadm" \
-	--include "${RAPIDO_DIR}/autorun/tgt_local.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
 	--modules "bash base" \

--- a/cut/usb_rbd.sh
+++ b/cut/usb_rbd.sh
@@ -31,12 +31,11 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	--include "$RAPIDO_DIR/autorun/usb_rbd.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
 	--include "$RBD_USB_SRC/rbd-usb.sh" "/bin/rbd-usb.sh" \
 	--include "$RBD_USB_SRC/conf-fs.sh" "/bin/conf-fs.sh" \
 	--include "$RBD_USB_SRC/rbd-usb.env" "/usr/lib/rbd-usb.env" \
 	--include "$RBD_USB_SRC/rbd-usb.conf" "/etc/rbd-usb/rbd-usb.conf" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod target_core_iblock usb_f_tcm \
 		       usb_f_mass_storage zram lzo lzo-rle dm-crypt" \
 	--modules "bash base" \

--- a/cut/usb_rbd.sh
+++ b/cut/usb_rbd.sh
@@ -16,7 +16,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/usb_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
@@ -30,7 +30,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
-	--include "$RAPIDO_DIR/autorun/usb_rbd.sh" "/.profile" \
 	--include "$RBD_USB_SRC/rbd-usb.sh" "/bin/rbd-usb.sh" \
 	--include "$RBD_USB_SRC/conf-fs.sh" "/bin/conf-fs.sh" \
 	--include "$RBD_USB_SRC/rbd-usb.env" "/usr/lib/rbd-usb.env" \

--- a/cut/zonefstests_nullblk.sh
+++ b/cut/zonefstests_nullblk.sh
@@ -15,14 +15,13 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_nullblk.sh"
 _rt_require_conf_dir ZONEFSTOOLS_SRC
 
 "$DRACUT" \
 	--install "ps rmdir dd id basename stat wc grep blkzone cut fio \
 		   rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
-	--include "$RAPIDO_DIR/autorun/zonefstests_nullblk.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "null_blk zonefs" \
 	--modules "bash base" \

--- a/cut/zonefstests_nullblk.sh
+++ b/cut/zonefstests_nullblk.sh
@@ -23,8 +23,7 @@ _rt_require_conf_dir ZONEFSTOOLS_SRC
 		   rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
 	--include "$RAPIDO_DIR/autorun/zonefstests_nullblk.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "null_blk zonefs" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/zonefstests_scsi.sh
+++ b/cut/zonefstests_scsi.sh
@@ -15,14 +15,13 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_scsi.sh"
 _rt_require_conf_dir ZONEFSTOOLS_SRC
 
 "$DRACUT" \
 	--install "ps rmdir dd id basename stat wc grep blkzone cut fio \
 		   rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
-	--include "$RAPIDO_DIR/autorun/zonefstests_scsi.sh" "/.profile" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "scsi_debug zonefs" \
 	--modules "bash base" \

--- a/cut/zonefstests_scsi.sh
+++ b/cut/zonefstests_scsi.sh
@@ -23,8 +23,7 @@ _rt_require_conf_dir ZONEFSTOOLS_SRC
 		   rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
 	--include "$RAPIDO_DIR/autorun/zonefstests_scsi.sh" "/.profile" \
-	--include "$RAPIDO_DIR/rapido.conf" "/rapido.conf" \
-	--include "$RAPIDO_DIR/vm_autorun.env" "/vm_autorun.env" \
+	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "scsi_debug zonefs" \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/runtime.vars
+++ b/runtime.vars
@@ -184,8 +184,11 @@ _rt_require_dracut_args() {
 	# specify core init scripts responsible for starting autorun
 	local conf_src="$RAPIDO_DIR/rapido.conf"
 	local env_src="$RAPIDO_DIR/vm_autorun.env"
+	local emerg_src="$RAPIDO_DIR/autorun/00-rapido-init.sh"
+	local emerg_dst="/lib/dracut/hooks/emergency/00-rapido-init.sh"
 	DRACUT_RAPIDO_INCLUDES="--include $conf_src /rapido.conf \
-				--include $env_src /vm_autorun.env"
+				--include $env_src /vm_autorun.env \
+				--include $emerg_src $emerg_dst"
 
 	# --confdir sees Dracut use rapido specific configuration, instead of
 	# processing /etc/dracut.conf.d/*.conf

--- a/runtime.vars
+++ b/runtime.vars
@@ -177,21 +177,37 @@ _rt_require_blktests() {
 }
 
 _rt_require_dracut_args() {
-	# first arg must correspond to a script that will be run on boot
-	local rapido_init=$1
-	[ -n "$rapido_init" ] \
+	# first arg must correspond to a script that will be run on boot.
+	# multiple scripts can be specified and will be run in the order of
+	# parameters. This order is controlled by prepending an index to the
+	# destination filename.
+	local init_src=$1
+	[ -n "$init_src" ] \
 		|| _fail "_rt_require_dracut_args missing autorun script param"
-	[ -x "$rapido_init" ] \
-		|| _fail "_rt_require_dracut_args autorun script not executable"
+
+	# start at 100 and strip first digit on use - hack for zero-padding
+	local i=100
+	while [ -n "$init_src" ]; do
+		[ -x "$init_src" ] \
+			|| _fail "_rt_require_dracut_args autorun script \
+				  $init_src not executable"
+		init_dst="/rapido_autorun/${i:1:3}-$(basename $init_src)"
+		DRACUT_RAPIDO_INCLUDES="$DRACUT_RAPIDO_INCLUDES \
+					--include $init_src $init_dst"
+
+		((i++))
+		shift
+		init_src=$1
+	done
 
 	# specify core init scripts responsible for starting autorun
 	local conf_src="$RAPIDO_DIR/rapido.conf"
 	local env_src="$RAPIDO_DIR/vm_autorun.env"
 	local emerg_src="$RAPIDO_DIR/autorun/00-rapido-init.sh"
 	local emerg_dst="/lib/dracut/hooks/emergency/00-rapido-init.sh"
-	DRACUT_RAPIDO_INCLUDES="--include $conf_src /rapido.conf \
+	DRACUT_RAPIDO_INCLUDES="$DRACUT_RAPIDO_INCLUDES
+				--include $conf_src /rapido.conf \
 				--include $env_src /.profile \
-				--include $rapido_init /rapido_autorun.sh \
 				--include $emerg_src $emerg_dst"
 
 	_rt_require_conf_dir KERNEL_SRC

--- a/runtime.vars
+++ b/runtime.vars
@@ -190,8 +190,8 @@ _rt_require_dracut_args() {
 	local emerg_src="$RAPIDO_DIR/autorun/00-rapido-init.sh"
 	local emerg_dst="/lib/dracut/hooks/emergency/00-rapido-init.sh"
 	DRACUT_RAPIDO_INCLUDES="--include $conf_src /rapido.conf \
-				--include $env_src /vm_autorun.env \
-				--include $rapido_init /.profile \
+				--include $env_src /.profile \
+				--include $rapido_init /rapido_autorun.sh \
 				--include $emerg_src $emerg_dst"
 
 	_rt_require_conf_dir KERNEL_SRC

--- a/runtime.vars
+++ b/runtime.vars
@@ -181,6 +181,12 @@ _rt_require_dracut_args() {
 	local kver="$(cat ${KERNEL_SRC}/include/config/kernel.release)"
 	[ -n "$kver" ] || _fail "failed to read kernel.release at $KERNEL_SRC"
 
+	# specify core init scripts responsible for starting autorun
+	local conf_src="$RAPIDO_DIR/rapido.conf"
+	local env_src="$RAPIDO_DIR/vm_autorun.env"
+	DRACUT_RAPIDO_INCLUDES="--include $conf_src /rapido.conf \
+				--include $env_src /vm_autorun.env"
+
 	# --confdir sees Dracut use rapido specific configuration, instead of
 	# processing /etc/dracut.conf.d/*.conf
 	local dracut_args="--confdir ${RAPIDO_DIR}/dracut.conf.d \

--- a/runtime.vars
+++ b/runtime.vars
@@ -188,9 +188,8 @@ _rt_require_dracut_args() {
 	# start at 100 and strip first digit on use - hack for zero-padding
 	local i=100
 	while [ -n "$init_src" ]; do
-		[ -x "$init_src" ] \
-			|| _fail "_rt_require_dracut_args autorun script \
-				  $init_src not executable"
+		[ -f "$init_src" ] \
+			|| _fail "_rt_require_dracut_args $init_src not a file"
 		init_dst="/rapido_autorun/${i:1:3}-$(basename $init_src)"
 		DRACUT_RAPIDO_INCLUDES="$DRACUT_RAPIDO_INCLUDES \
 					--include $init_src $init_dst"

--- a/runtime.vars
+++ b/runtime.vars
@@ -177,9 +177,12 @@ _rt_require_blktests() {
 }
 
 _rt_require_dracut_args() {
-	_rt_require_conf_dir KERNEL_SRC
-	local kver="$(cat ${KERNEL_SRC}/include/config/kernel.release)"
-	[ -n "$kver" ] || _fail "failed to read kernel.release at $KERNEL_SRC"
+	# first arg must correspond to a script that will be run on boot
+	local rapido_init=$1
+	[ -n "$rapido_init" ] \
+		|| _fail "_rt_require_dracut_args missing autorun script param"
+	[ -x "$rapido_init" ] \
+		|| _fail "_rt_require_dracut_args autorun script not executable"
 
 	# specify core init scripts responsible for starting autorun
 	local conf_src="$RAPIDO_DIR/rapido.conf"
@@ -188,7 +191,12 @@ _rt_require_dracut_args() {
 	local emerg_dst="/lib/dracut/hooks/emergency/00-rapido-init.sh"
 	DRACUT_RAPIDO_INCLUDES="--include $conf_src /rapido.conf \
 				--include $env_src /vm_autorun.env \
+				--include $rapido_init /.profile \
 				--include $emerg_src $emerg_dst"
+
+	_rt_require_conf_dir KERNEL_SRC
+	local kver="$(cat ${KERNEL_SRC}/include/config/kernel.release)"
+	[ -n "$kver" ] || _fail "failed to read kernel.release at $KERNEL_SRC"
 
 	# --confdir sees Dracut use rapido specific configuration, instead of
 	# processing /etc/dracut.conf.d/*.conf

--- a/vm.sh
+++ b/vm.sh
@@ -88,7 +88,7 @@ function _vm_start
 		-kernel "$QEMU_KERNEL_IMG" \
 		-initrd "$DRACUT_OUT" \
 		-append "rapido.vm_num=${vm_num} ip=${kern_ip_addr} \
-			 rd.systemd.unit=emergency \
+			 rd.systemd.unit=emergency.target \
 		         rd.shell=1 console=$QEMU_KERNEL_CONSOLE rd.lvm=0 rd.luks=0 \
 			 $QEMU_EXTRA_KERNEL_PARAMS" \
 		-pidfile "$vm_pid_file" \

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -154,3 +154,13 @@ export TERM="linux"
 export PS1="$(cat /proc/sys/kernel/hostname):\${PWD}# "
 resize &> /dev/null
 _vm_ar_virtfs_mount
+
+# The following can be removed when we expect all out-of-tree runners to have
+# been converted to the new boot sequence of:
+# dracut -> 00-rapido-init.sh -> .profile (vm_autorun.env) -> /rapido_autorun.sh
+	cat > /vm_autorun.env <<EOF
+echo vm_autorun.env: autorun scripts no longer need to source this file. It is \
+sourced via .profile automatically on boot prior to autorun invocation.
+EOF
+
+. /rapido_autorun.sh

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -168,4 +168,7 @@ echo vm_autorun.env: autorun scripts no longer need to source this file. It is \
 sourced via .profile automatically on boot prior to autorun invocation.
 EOF
 
-. /rapido_autorun.sh
+for f in /rapido_autorun/*; do
+	echo "Rapido: starting $f"
+	. "$f"
+done

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -24,6 +24,11 @@ function _fatal() {
 	sleep 2
 }
 
+# safety check to confirm that autorun scripts run from a rapido VM
+function _vm_ar_env_check {
+	[ -f /rapido.conf ]
+}
+
 # create /etc/hosts file with the essential IPv4 and IPv6 lines
 function _vm_ar_hosts_create
 {


### PR DESCRIPTION
This patchset fixes systemd based boots and also significantly cleans up the way autorun scripts are invoked.
Instead of hoping that the dracut emergency shell (after dumping rdsosreport) will magically trigger `/.profile`, we now use a proper emergency hook which is invoked earlier and allows complete control over subsequent autorun invocation.