### PR TITLE
Add a second network interface to VMs

### DIFF
--- a/autorun/ctdb_cephfs.sh
+++ b/autorun/ctdb_cephfs.sh
@@ -105,7 +105,7 @@ cat > /usr/local/samba/etc/ctdb/ctdb.conf << EOF
     recovery lock = !${reclock_bin} ceph $reclock_usr $reclock_pool $reclock_obj
 EOF
 
-echo $IP_ADDR1 >> /usr/local/samba/etc/ctdb/nodes
+echo $VM1_IP_ADDR1 >> /usr/local/samba/etc/ctdb/nodes
 echo $IP_ADDR2 >> /usr/local/samba/etc/ctdb/nodes
 
 ctdbd || _fatal
@@ -131,7 +131,7 @@ echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 
 ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM1_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then

--- a/autorun/ctdb_cephfs.sh
+++ b/autorun/ctdb_cephfs.sh
@@ -133,7 +133,7 @@ ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi
-ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
 fi

--- a/autorun/ctdb_cephfs.sh
+++ b/autorun/ctdb_cephfs.sh
@@ -129,7 +129,7 @@ smbd || _fatal
 echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 	| smbpasswd -a $CIFS_USER -s || _fatal
 
-ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi

--- a/autorun/ctdb_cephfs.sh
+++ b/autorun/ctdb_cephfs.sh
@@ -106,7 +106,7 @@ cat > /usr/local/samba/etc/ctdb/ctdb.conf << EOF
 EOF
 
 echo $VM1_IP_ADDR1 >> /usr/local/samba/etc/ctdb/nodes
-echo $IP_ADDR2 >> /usr/local/samba/etc/ctdb/nodes
+echo $VM2_IP_ADDR1 >> /usr/local/samba/etc/ctdb/nodes
 
 ctdbd || _fatal
 
@@ -135,6 +135,6 @@ if [ $? -eq 0 ]; then
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM2_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 echo "Logs at /usr/local/samba/var/log/log.ctdb & /usr/local/samba/var/log.smbd"

--- a/autorun/fcoe_local.sh
+++ b/autorun/fcoe_local.sh
@@ -148,7 +148,7 @@ if [ $? -eq 0 ]; then
 	file_path=/var/target/lun
 	file_size_b=1073741824
 	target_wwn="20:00:$VM1_MAC_ADDR1"
-	initiator_wwn="20:00:$MAC_ADDR2"
+	initiator_wwn="20:00:$VM2_MAC_ADDR1"
 
 	create_fcoe "eth0"
 	create_fileio ${file_path} ${file_size_b}
@@ -158,7 +158,7 @@ if [ $? -eq 0 ]; then
 	echo "${file_path} exported via FCoE on $VM1_MAC_ADDR1"
 fi
 
-ip link show eth0 | grep $MAC_ADDR2
+ip link show eth0 | grep $VM2_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	fipvlan -csum vn2vn eth0 || _fatal
 	udevadm settle

--- a/autorun/fcoe_local.sh
+++ b/autorun/fcoe_local.sh
@@ -143,11 +143,11 @@ find_fcoedev() {
 	done
 }
 
-ip link show eth0 | grep $MAC_ADDR1
+ip link show eth0 | grep $VM1_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	file_path=/var/target/lun
 	file_size_b=1073741824
-	target_wwn="20:00:$MAC_ADDR1"
+	target_wwn="20:00:$VM1_MAC_ADDR1"
 	initiator_wwn="20:00:$MAC_ADDR2"
 
 	create_fcoe "eth0"
@@ -155,7 +155,7 @@ if [ $? -eq 0 ]; then
 	create_target ${target_wwn}
 	create_acl ${target_wwn} ${initiator_wwn}
 
-	echo "${file_path} exported via FCoE on $MAC_ADDR1"
+	echo "${file_path} exported via FCoE on $VM1_MAC_ADDR1"
 fi
 
 ip link show eth0 | grep $MAC_ADDR2
@@ -164,7 +164,7 @@ if [ $? -eq 0 ]; then
 	udevadm settle
 
 	bdev=$(find_fcoedev)
-	echo "Remote FCoE $MAC_ADDR1 mapped to /dev/$bdev"
+	echo "Remote FCoE $VM1_MAC_ADDR1 mapped to /dev/$bdev"
 fi
 
 set +x

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -235,7 +235,7 @@ for iblock_dev in $export_blockdevs; do
 done
 
 # standalone iSCSI target - listen on ports 3260 and 3261 of assigned address
-ip link show eth0 | grep $MAC_ADDR1
+ip link show eth0 | grep $VM1_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${IP_ADDR1}:3260 \
 		|| _fatal

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -237,13 +237,13 @@ done
 # standalone iSCSI target - listen on ports 3260 and 3261 of assigned address
 ip link show eth0 | grep $VM1_MAC_ADDR1
 if [ $? -eq 0 ]; then
-	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${IP_ADDR1}:3260 \
+	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${VM1_IP_ADDR1}:3260 \
 		|| _fatal
-	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${IP_ADDR1}:3261 \
+	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${VM1_IP_ADDR1}:3261 \
 		|| _fatal
 
-	echo "target ready at: iscsi://${IP_ADDR1}:3260/${TARGET_IQN}/"
-	echo "target ready at: iscsi://${IP_ADDR1}:3261/${TARGET_IQN}/"
+	echo "target ready at: iscsi://${VM1_IP_ADDR1}:3260/${TARGET_IQN}/"
+	echo "target ready at: iscsi://${VM1_IP_ADDR1}:3261/${TARGET_IQN}/"
 fi
 
 ip link show eth0 | grep $VM2_MAC_ADDR1

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -248,13 +248,13 @@ fi
 
 ip link show eth0 | grep $VM2_MAC_ADDR1
 if [ $? -eq 0 ]; then
-	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${IP_ADDR2}:3260 \
+	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${VM2_IP_ADDR1}:3260 \
 		|| _fatal
-	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${IP_ADDR2}:3261 \
+	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${VM2_IP_ADDR1}:3261 \
 		|| _fatal
 
-	echo "target ready at: iscsi://${IP_ADDR2}:3260/${TARGET_IQN}/"
-	echo "target ready at: iscsi://${IP_ADDR2}:3261/${TARGET_IQN}/"
+	echo "target ready at: iscsi://${VM2_IP_ADDR1}:3260/${TARGET_IQN}/"
+	echo "target ready at: iscsi://${VM2_IP_ADDR1}:3261/${TARGET_IQN}/"
 fi
 echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/enable
 echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/enable

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -246,7 +246,7 @@ if [ $? -eq 0 ]; then
 	echo "target ready at: iscsi://${IP_ADDR1}:3261/${TARGET_IQN}/"
 fi
 
-ip link show eth0 | grep $MAC_ADDR2
+ip link show eth0 | grep $VM2_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${IP_ADDR2}:3260 \
 		|| _fatal

--- a/autorun/lio_rbd.sh
+++ b/autorun/lio_rbd.sh
@@ -141,7 +141,7 @@ set +x
 # new portals are disabled by default
 mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${VM1_IP_ADDR1}:3260 \
 	|| _fatal
-mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${IP_ADDR2}:3260 \
+mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${VM2_IP_ADDR1}:3260 \
 	|| _fatal
 
 # only enable portal for corresponding MAC/IP
@@ -154,5 +154,5 @@ fi
 ip link show eth0 | grep $VM2_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/enable
-	echo "target ready at: iscsi://${IP_ADDR2}:3260/${TARGET_IQN}/"
+	echo "target ready at: iscsi://${VM2_IP_ADDR1}:3260/${TARGET_IQN}/"
 fi

--- a/autorun/lio_rbd.sh
+++ b/autorun/lio_rbd.sh
@@ -139,7 +139,7 @@ done
 set +x
 
 # new portals are disabled by default
-mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${IP_ADDR1}:3260 \
+mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/np/${VM1_IP_ADDR1}:3260 \
 	|| _fatal
 mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${IP_ADDR2}:3260 \
 	|| _fatal
@@ -148,7 +148,7 @@ mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${IP_ADDR2}:3260 \
 ip link show eth0 | grep $VM1_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/enable
-	echo "target ready at: iscsi://${IP_ADDR1}:3260/${TARGET_IQN}/"
+	echo "target ready at: iscsi://${VM1_IP_ADDR1}:3260/${TARGET_IQN}/"
 fi
 
 ip link show eth0 | grep $VM2_MAC_ADDR1

--- a/autorun/lio_rbd.sh
+++ b/autorun/lio_rbd.sh
@@ -151,7 +151,7 @@ if [ $? -eq 0 ]; then
 	echo "target ready at: iscsi://${IP_ADDR1}:3260/${TARGET_IQN}/"
 fi
 
-ip link show eth0 | grep $MAC_ADDR2
+ip link show eth0 | grep $VM2_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/enable
 	echo "target ready at: iscsi://${IP_ADDR2}:3260/${TARGET_IQN}/"

--- a/autorun/lio_rbd.sh
+++ b/autorun/lio_rbd.sh
@@ -145,7 +145,7 @@ mkdir /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_2/np/${IP_ADDR2}:3260 \
 	|| _fatal
 
 # only enable portal for corresponding MAC/IP
-ip link show eth0 | grep $MAC_ADDR1
+ip link show eth0 | grep $VM1_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_1/enable
 	echo "target ready at: iscsi://${IP_ADDR1}:3260/${TARGET_IQN}/"

--- a/autorun/lrbd.sh
+++ b/autorun/lrbd.sh
@@ -77,7 +77,7 @@ cat > lrbd.conf.json << EOF
   "portals": [
       {
           "name": "portal1",
-          "addresses": [ "$IP_ADDR1" ]
+          "addresses": [ "$VM1_IP_ADDR1" ]
       },
       {
           "name": "portal2",

--- a/autorun/lrbd.sh
+++ b/autorun/lrbd.sh
@@ -81,7 +81,7 @@ cat > lrbd.conf.json << EOF
       },
       {
           "name": "portal2",
-          "addresses": [ "$IP_ADDR2"  ]
+          "addresses": [ "$VM2_IP_ADDR1"  ]
       }
   ],
   "pools": [

--- a/autorun/lrbd.sh
+++ b/autorun/lrbd.sh
@@ -68,8 +68,8 @@ cat > lrbd.conf.json << EOF
   "targets": [
       {
         "hosts": [
-            { "host": "$HOSTNAME1", "portal": "portal1" },
-            { "host": "$HOSTNAME2", "portal": "portal2" }
+            { "host": "$VM1_HOSTNAME", "portal": "portal1" },
+            { "host": "$VM2_HOSTNAME", "portal": "portal2" }
         ],
         "target": "$TARGET_IQN"
       }

--- a/autorun/nvme_rdma.sh
+++ b/autorun/nvme_rdma.sh
@@ -87,7 +87,7 @@ if [ $? -eq 0 ]; then
 	echo "$export_blockdev mapped via NVMe over Fabrics RDMA on $IP_ADDR1"
 fi
 
-ip link show eth0 | grep $MAC_ADDR2
+ip link show eth0 | grep $VM2_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	nvme connect -t rdma -a $IP_ADDR1 -s 4420 -n nvmf-test || _fatal
 	udevadm settle

--- a/autorun/nvme_rdma.sh
+++ b/autorun/nvme_rdma.sh
@@ -58,7 +58,7 @@ echo eth0 > /sys/module/rdma_rxe/parameters/add
 nvmet_cfs="/sys/kernel/config/nvmet/"
 nvmet_subsystem="nvmf-test"
 
-ip link show eth0 | grep $MAC_ADDR1
+ip link show eth0 | grep $VM1_MAC_ADDR1
 if [ $? -eq 0 ]; then
 	export_blockdev=$(_zram_hot_add "1G")
 	[ -b "$export_blockdev" ] || _fatal "$export_blockdev device not available"

--- a/autorun/nvme_rdma.sh
+++ b/autorun/nvme_rdma.sh
@@ -77,22 +77,22 @@ if [ $? -eq 0 ]; then
 	mkdir ${nvmet_cfs}/ports/1 || _fatal
 
 	echo rdma > ${nvmet_cfs}/ports/1/addr_trtype || _fatal
-	echo $IP_ADDR1 > ${nvmet_cfs}/ports/1/addr_traddr || _fatal
+	echo $VM1_IP_ADDR1 > ${nvmet_cfs}/ports/1/addr_traddr || _fatal
 	echo ipv4 > ${nvmet_cfs}/ports/1/addr_adrfam || _fatal
 	echo 4420 > ${nvmet_cfs}/ports/1/addr_trsvcid || _fatal
 	ln -s ${nvmet_cfs}/subsystems/${nvmet_subsystem} \
 		${nvmet_cfs}/ports/1/subsystems/${nvmet_subsystem} || _fatal
 
 	set +x
-	echo "$export_blockdev mapped via NVMe over Fabrics RDMA on $IP_ADDR1"
+	echo "$export_blockdev mapped via NVMe over Fabrics RDMA on $VM1_IP_ADDR1"
 fi
 
 ip link show eth0 | grep $VM2_MAC_ADDR1
 if [ $? -eq 0 ]; then
-	nvme connect -t rdma -a $IP_ADDR1 -s 4420 -n nvmf-test || _fatal
+	nvme connect -t rdma -a $VM1_IP_ADDR1 -s 4420 -n nvmf-test || _fatal
 	udevadm settle
 	nvmedev=$(ls /dev/ | grep -Eo /dev/nvme[0-9]n[0-0])
 	set +x
-	echo "Remote NVMe over RDMA $IP_ADDR1 mapped to $nvmedev"
+	echo "Remote NVMe over RDMA $VM1_IP_ADDR1 mapped to $nvmedev"
 fi
 

--- a/autorun/samba_cephfs.sh
+++ b/autorun/samba_cephfs.sh
@@ -70,6 +70,6 @@ if [ $? -eq 0 ]; then
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM2_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 echo "Log at: /usr/local/samba/var/log.smbd"

--- a/autorun/samba_cephfs.sh
+++ b/autorun/samba_cephfs.sh
@@ -64,7 +64,7 @@ set +x
 echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 	| smbpasswd -a $CIFS_USER -s || _fatal
 
-ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi

--- a/autorun/samba_cephfs.sh
+++ b/autorun/samba_cephfs.sh
@@ -66,7 +66,7 @@ echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 
 ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM1_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then

--- a/autorun/samba_cephfs.sh
+++ b/autorun/samba_cephfs.sh
@@ -68,7 +68,7 @@ ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi
-ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
 fi

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -61,7 +61,7 @@ echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 
 ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM1_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -63,7 +63,7 @@ ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi
-ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
 fi

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -65,6 +65,6 @@ if [ $? -eq 0 ]; then
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM2_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 echo "Log at: /usr/local/samba/var/log.smbd"

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -59,7 +59,7 @@ set +x
 echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 	| smbpasswd -a $CIFS_USER -s || _fatal
 
-ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi

--- a/autorun/samba_local.sh
+++ b/autorun/samba_local.sh
@@ -75,6 +75,6 @@ if [ $? -eq 0 ]; then
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM2_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 echo "Log at: /usr/local/samba/var/log.smbd"

--- a/autorun/samba_local.sh
+++ b/autorun/samba_local.sh
@@ -69,7 +69,7 @@ set +x
 echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 	| smbpasswd -a $CIFS_USER -s || _fatal
 
-ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi

--- a/autorun/samba_local.sh
+++ b/autorun/samba_local.sh
@@ -73,7 +73,7 @@ ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
 fi
-ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	echo "Samba share ready at: //${IP_ADDR2}/${CIFS_SHARE}/"
 fi

--- a/autorun/samba_local.sh
+++ b/autorun/samba_local.sh
@@ -71,7 +71,7 @@ echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
 
 ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	echo "Samba share ready at: //${IP_ADDR1}/${CIFS_SHARE}/"
+	echo "Samba share ready at: //${VM1_IP_ADDR1}/${CIFS_SHARE}/"
 fi
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then

--- a/autorun/tgt_local.sh
+++ b/autorun/tgt_local.sh
@@ -28,7 +28,7 @@ if [ $? -eq 0 ]; then
 	addr="${IP_ADDR1}"
 fi
 
-ip link show eth0 | grep $MAC_ADDR2 &> /dev/null
+ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	addr="${IP_ADDR2}"
 fi

--- a/autorun/tgt_local.sh
+++ b/autorun/tgt_local.sh
@@ -25,7 +25,7 @@ echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"
 addr=""
 ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	addr="${IP_ADDR1}"
+	addr="${VM1_IP_ADDR1}"
 fi
 
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null

--- a/autorun/tgt_local.sh
+++ b/autorun/tgt_local.sh
@@ -30,7 +30,7 @@ fi
 
 ip link show eth0 | grep $VM2_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
-	addr="${IP_ADDR2}"
+	addr="${VM2_IP_ADDR1}"
 fi
 
 [ -z "$addr" ] && _fatal "VM network config missing"

--- a/autorun/tgt_local.sh
+++ b/autorun/tgt_local.sh
@@ -23,7 +23,7 @@ _vm_ar_dyn_debug_enable
 echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"
 
 addr=""
-ip link show eth0 | grep $MAC_ADDR1 &> /dev/null
+ip link show eth0 | grep $VM1_MAC_ADDR1 &> /dev/null
 if [ $? -eq 0 ]; then
 	addr="${IP_ADDR1}"
 fi

--- a/cut/blktests_rbd.sh
+++ b/cut/blktests_rbd.sh
@@ -24,12 +24,13 @@ _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_blktests
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   getopt tput wc column blktrace losetup parted truncate \
-		   lsblk strace which awk bc touch cut chmod true false mktemp \
-		   killall id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep hexdump sync fio logger cmp stat nproc \
-		   xfs_io modinfo blkdiscard realpath timeout ip ping" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		getopt tput wc column blktrace losetup parted truncate \
+		lsblk strace which awk bc touch cut chmod true false mktemp \
+		killall id sort uniq date expr tac diff head dirname seq \
+		basename tee egrep hexdump sync fio logger cmp stat nproc \
+		xfs_io modinfo blkdiscard realpath timeout ip ping" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/blktests_zram.sh
+++ b/cut/blktests_zram.sh
@@ -18,12 +18,13 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/blktests_zram.sh"
 _rt_require_blktests
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   getopt tput wc column blktrace losetup parted truncate \
-		   lsblk strace which awk bc touch cut chmod true false mktemp \
-		   killall id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep hexdump sync fio logger cmp stat nproc \
-		   xfs_io modinfo blkdiscard realpath timeout nvme" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		getopt tput wc column blktrace losetup parted truncate \
+		lsblk strace which awk bc touch cut chmod true false mktemp \
+		killall id sort uniq date expr tac diff head dirname seq \
+		basename tee egrep hexdump sync fio logger cmp stat nproc \
+		xfs_io modinfo blkdiscard realpath timeout nvme" \
 	--include "$BLKTESTS_SRC" "/blktests" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle scsi_debug null_blk loop nvme nvme-loop" \

--- a/cut/cephfs.sh
+++ b/cut/cephfs.sh
@@ -23,10 +23,11 @@ _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs.sh"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace stat which touch cut chmod true false \
-		   getfattr setfattr getfacl setfacl killall sync \
-		   id sort uniq date expr tac diff head dirname seq ip ping" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace stat which touch cut chmod true false \
+		getfattr setfattr getfacl setfacl killall sync \
+		id sort uniq date expr tac diff head dirname seq ip ping" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "ceph libceph" \
 	--modules "bash base" \

--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -26,11 +26,12 @@ _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs_fuse.sh"
 _rt_require_lib "libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
-"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
-		   strace stat truncate touch cut chmod getfattr setfattr \
-		   getfacl setfacl killall sync dirname seq ip ping \
-		   $CEPH_FUSE_BIN \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail ps rmdir resize dd vim grep find df sha256sum \
+		strace stat truncate touch cut chmod getfattr setfattr \
+		getfacl setfacl killall sync dirname seq ip ping \
+		$CEPH_FUSE_BIN \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \

--- a/cut/cifs.sh
+++ b/cut/cifs.sh
@@ -17,11 +17,12 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/cifs.sh"
 
-"$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
-		   mount.cifs ip ping getfacl setfacl truncate du \
-		   which touch cut chmod true false unlink \
-		   getfattr setfattr chacl attr killall sync \
-		   dirname seq basename fstrim chattr lsattr stat" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail ps rmdir resize dd vim grep find df \
+		mount.cifs ip ping getfacl setfacl truncate du \
+		which touch cut chmod true false unlink \
+		getfattr setfattr chacl attr killall sync \
+		dirname seq basename fstrim chattr lsattr stat" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm gcm ctr" \
 	--modules "bash base" \

--- a/cut/ctdb_cephfs.sh
+++ b/cut/ctdb_cephfs.sh
@@ -31,29 +31,30 @@ _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 # - ctdb_event -> ctdb-event
 # - config/events.d -> config/events
 # - ctdb-config & ctdb-path -> new binaries
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace xargs timeout \
-		   which perl awk bc touch cut chmod true false \
-		   getfattr setfattr chacl attr killall sync \
-		   id sort uniq date expr tac diff head dirname seq ip ping \
-		   ${SAMBA_SRC}/bin/smbpasswd \
-		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/modules/vfs/ceph.so \
-		   ${SAMBA_SRC}/bin/smbd \
-		   ${SAMBA_SRC}/bin/tdbtool \
-		   ${SAMBA_SRC}/bin/ctdb \
-		   ${SAMBA_SRC}/bin/ctdb-config \
-		   ${SAMBA_SRC}/bin/ctdbd \
-		   ${SAMBA_SRC}/bin/ctdb?event \
-		   ${SAMBA_SRC}/bin/ctdb?eventd \
-		   ${SAMBA_SRC}/bin/ctdb_killtcp \
-		   ${SAMBA_SRC}/bin/ctdb_lock_helper \
-		   ${SAMBA_SRC}/bin/ctdb_mutex_fcntl_helper \
-		   ${SAMBA_SRC}/bin/ctdb-path \
-		   ${SAMBA_SRC}/bin/ctdb_recovery_helper \
-		   ${SAMBA_SRC}/bin/ctdb_takeover_helper \
-		   ${SAMBA_SRC}/bin/ctdb_mutex_ceph_rados_helper \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace xargs timeout \
+		which perl awk bc touch cut chmod true false \
+		getfattr setfattr chacl attr killall sync \
+		id sort uniq date expr tac diff head dirname seq ip ping \
+		${SAMBA_SRC}/bin/smbpasswd \
+		${SAMBA_SRC}/bin/smbstatus \
+		${SAMBA_SRC}/bin/modules/vfs/ceph.so \
+		${SAMBA_SRC}/bin/smbd \
+		${SAMBA_SRC}/bin/tdbtool \
+		${SAMBA_SRC}/bin/ctdb \
+		${SAMBA_SRC}/bin/ctdb-config \
+		${SAMBA_SRC}/bin/ctdbd \
+		${SAMBA_SRC}/bin/ctdb?event \
+		${SAMBA_SRC}/bin/ctdb?eventd \
+		${SAMBA_SRC}/bin/ctdb_killtcp \
+		${SAMBA_SRC}/bin/ctdb_lock_helper \
+		${SAMBA_SRC}/bin/ctdb_mutex_fcntl_helper \
+		${SAMBA_SRC}/bin/ctdb-path \
+		${SAMBA_SRC}/bin/ctdb_recovery_helper \
+		${SAMBA_SRC}/bin/ctdb_takeover_helper \
+		${SAMBA_SRC}/bin/ctdb_mutex_ceph_rados_helper \
+		$LIBS_INSTALL_LIST" \
 	--include "$CTDB_EVENTS_DIR" "$CTDB_EVENTS_DIR" \
 	--include "${SAMBA_SRC}/ctdb/config/functions" \
 		  "/usr/local/samba/etc/ctdb/functions" \

--- a/cut/dropbear.sh
+++ b/cut/dropbear.sh
@@ -18,9 +18,10 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/dropbear.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs dropbear chmod ip ping \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs dropbear chmod ip ping \
+		$LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/fcoe_local.sh
+++ b/cut/fcoe_local.sh
@@ -17,10 +17,11 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fcoe_local.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs killall truncate dirname fipvlan basename \
-		   ip ping \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs killall truncate dirname fipvlan basename \
+		ip ping \
+		$LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod tcm_fc target_core_iblock \
 			target_core_file libfc fcoe scsi_debug" \

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -19,23 +19,24 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs.sh"
 _rt_require_fstests
 _rt_require_btrfs_progs
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs  free \
-		   which perl awk bc touch cut chmod true false unlink \
-		   mktemp getfattr setfattr chacl attr killall hexdump sync \
-		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep yes mkswap timeout \
-		   fstrim fio logger dmsetup chattr lsattr cmp stat \
-		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
-		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
-		   repquota setquota quotacheck quotaon pvremove vgremove \
-		   xfs_mkfile xfs_db xfs_io wipefs filefrag losetup\
-		   chgrp du fgrep pgrep tar rev kill duperemove \
-		   swapon swapoff xfs_freeze fsck \
-		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
-		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/*
-		   $BTRFS_PROGS_BINS" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs  free \
+		which perl awk bc touch cut chmod true false unlink \
+		mktemp getfattr setfattr chacl attr killall hexdump sync \
+		id sort uniq date expr tac diff head dirname seq \
+		basename tee egrep yes mkswap timeout \
+		fstrim fio logger dmsetup chattr lsattr cmp stat \
+		dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		repquota setquota quotacheck quotaon pvremove vgremove \
+		xfs_mkfile xfs_db xfs_io wipefs filefrag losetup\
+		chgrp du fgrep pgrep tar rev kill duperemove \
+		swapon swapoff xfs_freeze fsck \
+		${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		${FSTESTS_SRC}/src/log-writes/* \
+		${FSTESTS_SRC}/src/aio-dio-regress/*
+		$BTRFS_PROGS_BINS" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -24,21 +24,22 @@ _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_fstests
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs free \
-		   which perl awk bc touch cut chmod true false unlink \
-		   mktemp getfattr setfattr chacl attr killall hexdump sync \
-		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep yes \
-		   fstrim fio logger dmsetup chattr lsattr cmp stat \
-		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
-		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
-		   repquota setquota quotacheck quotaon pvremove vgremove \
-		   xfs_mkfile xfs_db xfs_io \
-		   chgrp du fgrep pgrep tar rev kill ip ping \
-		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
-		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs free \
+		which perl awk bc touch cut chmod true false unlink \
+		mktemp getfattr setfattr chacl attr killall hexdump sync \
+		id sort uniq date expr tac diff head dirname seq \
+		basename tee egrep yes \
+		fstrim fio logger dmsetup chattr lsattr cmp stat \
+		dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		repquota setquota quotacheck quotaon pvremove vgremove \
+		xfs_mkfile xfs_db xfs_io \
+		chgrp du fgrep pgrep tar rev kill ip ping \
+		${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		${FSTESTS_SRC}/src/log-writes/* \
+		${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -18,21 +18,22 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cifs.sh"
 _rt_require_fstests
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mount.cifs free \
-		   which perl awk bc touch cut chmod true false unlink \
-		   mktemp getfattr setfattr chacl attr killall hexdump sync \
-		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep yes \
-		   fstrim fio logger dmsetup chattr lsattr cmp stat \
-		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
-		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
-		   repquota setquota quotacheck quotaon pvremove vgremove \
-		   xfs_mkfile xfs_db xfs_io \
-		   chgrp du fgrep pgrep tar rev kill ip ping \
-		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
-		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs mount.cifs free \
+		which perl awk bc touch cut chmod true false unlink \
+		mktemp getfattr setfattr chacl attr killall hexdump sync \
+		id sort uniq date expr tac diff head dirname seq \
+		basename tee egrep yes \
+		fstrim fio logger dmsetup chattr lsattr cmp stat \
+		dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		repquota setquota quotacheck quotaon pvremove vgremove \
+		xfs_mkfile xfs_db xfs_io \
+		chgrp du fgrep pgrep tar rev kill ip ping \
+		${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		${FSTESTS_SRC}/src/log-writes/* \
+		${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm ctr" \

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -18,23 +18,24 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_xfs.sh"
 _rt_require_fstests
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.xfs free \
-		   which perl awk bc touch cut chmod true false unlink \
-		   mktemp getfattr setfattr chacl attr killall hexdump sync \
-		   id sort uniq date expr tac diff head dirname seq \
-		   basename tee egrep yes \
-		   fstrim fio logger dmsetup chattr lsattr cmp stat \
-		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
-		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
-		   repquota setquota quotacheck quotaon pvremove vgremove \
-		   xfs_mkfile xfs_db xfs_io fsck \
-		   xfs_mdrestore xfs_bmap xfs_fsr xfsdump xfs_freeze xfs_info \
-		   xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_metadump \
-		   chgrp du fgrep pgrep tar rev kill duperemove \
-		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
-		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs mkfs.xfs free \
+		which perl awk bc touch cut chmod true false unlink \
+		mktemp getfattr setfattr chacl attr killall hexdump sync \
+		id sort uniq date expr tac diff head dirname seq \
+		basename tee egrep yes \
+		fstrim fio logger dmsetup chattr lsattr cmp stat \
+		dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		repquota setquota quotacheck quotaon pvremove vgremove \
+		xfs_mkfile xfs_db xfs_io fsck \
+		xfs_mdrestore xfs_bmap xfs_fsr xfsdump xfs_freeze xfs_info \
+		xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_metadump \
+		chgrp du fgrep pgrep tar rev kill duperemove \
+		${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		${FSTESTS_SRC}/src/log-writes/* \
+		${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey xfs" \

--- a/cut/lio_local.sh
+++ b/cut/lio_local.sh
@@ -17,9 +17,10 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_local.sh"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs truncate losetup dmsetup \
-		   /usr/lib/udev/rules.d/95-dm-notify.rules ip ping" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs truncate losetup dmsetup \
+		/usr/lib/udev/rules.d/95-dm-notify.rules ip ping" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_iblock \
 		       target_core_file dm-delay loop" \

--- a/cut/lio_pscsi_loop.sh
+++ b/cut/lio_pscsi_loop.sh
@@ -22,9 +22,10 @@ _rt_require_dracut_args "${RAPIDO_DIR}/autorun/lio_pscsi_loop.sh"
 #   -drive if=none,id=hda,file=/dev/zram0,cache=none,format=raw,serial=RAPIDO \
 #   -device scsi-hd,drive=hda"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   mkfs mkfs.xfs parted partprobe sgdisk hdparm uuidgen \
-		   env lsscsi awk" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		mkfs mkfs.xfs parted partprobe sgdisk hdparm uuidgen \
+		env lsscsi awk" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi target_core_pscsi tcm_loop" \
 	--modules "bash base" \

--- a/cut/lio_rbd.sh
+++ b/cut/lio_rbd.sh
@@ -24,9 +24,10 @@ _rt_write_ceph_config $vm_ceph_conf
 _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lio_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs ip ping \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs ip ping \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/lrbd.sh
+++ b/cut/lrbd.sh
@@ -36,10 +36,11 @@ rados_cython="${CEPH_SRC}"/build/lib/cython_modules/lib.3/rados.cpython-34m.so
 [ -x "$rados_cython" ] || _fail "rados cython library missing at $rados_cython"
 
 # ldconfig needed by pyudev ctypes.util.find_library
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df \
-		   $py3_files env ldconfig ip ping \
-		   dbus-daemon /etc/dbus-1/system.conf $rbd_bin $rados_cython \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df \
+		$py3_files env ldconfig ip ping \
+		dbus-daemon /etc/dbus-1/system.conf $rbd_bin $rados_cython \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -18,8 +18,8 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/ltp.sh"
 _rt_require_conf_dir LTP_DIR
 
-"$DRACUT" \
-	--install "tail blockdev ps rmdir resize dd grep find df mkfs which \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd grep find df mkfs which \
 		perl awk bc touch cut chmod true false unlink mktemp getfattr \
 		setfattr attr killall hexdump sync id sort uniq date expr tac \
 		diff head dirname seq basename tee egrep yes dmsetup chattr \

--- a/cut/mpath_local.sh
+++ b/cut/mpath_local.sh
@@ -28,9 +28,10 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/mpath_local.sh"
 # Once booted, you can simulate path failure by switching to the QEMU console
 # (ctrl-a c) and running "drive_del hda"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.xfs parted partprobe sgdisk hdparm \
-		   timeout id chown chmod env killall getopt basename" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs mkfs.xfs parted partprobe sgdisk hdparm \
+		timeout id chown chmod env killall getopt basename" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi virtio_pci sd_mod" \
 	--modules "bash base systemd systemd-initrd dracut-systemd multipath" \

--- a/cut/nvme_local.sh
+++ b/cut/nvme_local.sh
@@ -18,9 +18,10 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_local.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs \
+		$LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet zram lzo lzo-rle" \
 	--modules "bash base" \

--- a/cut/nvme_rbd.sh
+++ b/cut/nvme_rbd.sh
@@ -24,9 +24,10 @@ _rt_write_ceph_config $vm_ceph_conf
 _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs ip ping \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs ip ping \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/nvme_rdma.sh
+++ b/cut/nvme_rdma.sh
@@ -18,9 +18,10 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rdma.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs killall nvme ip ping \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs killall nvme ip ping \
+		$LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \
 		       rdma_rxe zram lzo lzo-rle ib_core ib_uverbs rdma_ucm \

--- a/cut/nvme_tcp_initiator.sh
+++ b/cut/nvme_tcp_initiator.sh
@@ -17,8 +17,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_tcp_initiator.sh"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs ip ping" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs ip ping" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-tcp" \

--- a/cut/nvme_tcp_rbd.sh
+++ b/cut/nvme_tcp_rbd.sh
@@ -24,9 +24,10 @@ _rt_write_ceph_config $vm_ceph_conf
 _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs ip ping \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs ip ping \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/openiscsi.sh
+++ b/cut/openiscsi.sh
@@ -18,11 +18,11 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "${RAPIDO_DIR}/autorun/openiscsi.sh"
 _rt_require_conf_dir OPENISCSI_SRC
 
-"$DRACUT" \
-	--install "grep ps dd mkfs.xfs ip ping \
-		   ${OPENISCSI_SRC}/usr/iscsid \
-		   ${OPENISCSI_SRC}/libopeniscsiusr/libopeniscsiusr.so \
-		   ${OPENISCSI_SRC}/usr/iscsiadm" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		grep ps dd mkfs.xfs ip ping \
+		${OPENISCSI_SRC}/usr/iscsid \
+		${OPENISCSI_SRC}/libopeniscsiusr/libopeniscsiusr.so \
+		${OPENISCSI_SRC}/usr/iscsiadm" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	--drivers "iscsi_tcp" \

--- a/cut/qemu_rbd.sh
+++ b/cut/qemu_rbd.sh
@@ -19,9 +19,10 @@ _rt_require_dracut_args
 _rt_require_ceph
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs lsscsi \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs lsscsi \
+		$LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--modules "bash base" \
 	$DRACUT_EXTRA_ARGS \

--- a/cut/rbd.sh
+++ b/cut/rbd.sh
@@ -24,9 +24,10 @@ _rt_write_ceph_config $vm_ceph_conf
 _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs ip ping \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs ip ping \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/rbd_nbd.sh
+++ b/cut/rbd_nbd.sh
@@ -30,9 +30,10 @@ _rt_require_lib "libsoftokn3.so libsqlite3.so \
 rbd_nbd_bin="${CEPH_SRC}/build/bin/rbd-nbd"
 [ -x "$rbd_nbd_bin" ] || _fail "rbd-nbd executable missing at $rbd_nbd_bin"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs mkfs.btrfs sync dirname uuidgen sleep ip ping \
-		   $LIBS_INSTALL_LIST $rbd_nbd_bin" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs mkfs.btrfs sync dirname uuidgen sleep ip ping \
+		$LIBS_INSTALL_LIST $rbd_nbd_bin" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -26,15 +26,16 @@ _rt_require_conf_dir SAMBA_SRC
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
-"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
-		   which touch cut chmod true false \
-		   getfattr setfattr chacl attr killall sync \
-		   id sort uniq date expr tac diff head dirname seq ip ping \
-		   ${SAMBA_SRC}/bin/smbpasswd \
-		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/modules/vfs/ceph.so \
-		   ${SAMBA_SRC}/bin/smbd \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail ps rmdir resize dd vim grep find df sha256sum \
+		which touch cut chmod true false \
+		getfattr setfattr chacl attr killall sync \
+		id sort uniq date expr tac diff head dirname seq ip ping \
+		${SAMBA_SRC}/bin/smbpasswd \
+		${SAMBA_SRC}/bin/smbstatus \
+		${SAMBA_SRC}/bin/modules/vfs/ceph.so \
+		${SAMBA_SRC}/bin/smbd \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_COMMON_LIB" "/usr/lib64/libceph-common.so.0" \
 	--include "$CEPHFS_LIB" "/usr/lib64/libcephfs.so.2" \
 	--include "$CEPH_RADOS_LIB" "/usr/lib64/librados.so.2" \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -25,13 +25,14 @@ _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC
 
-"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
-		   strace stat which touch cut chmod true false \
-		   getfattr setfattr getfacl setfacl killall sync \
-		   id sort uniq date expr tac diff head dirname seq ip ping \
-		   ${SAMBA_SRC}/bin/smbpasswd \
-		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/smbd" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail ps rmdir resize dd vim grep find df sha256sum \
+		strace stat which touch cut chmod true false \
+		getfattr setfattr getfacl setfacl killall sync \
+		id sort uniq date expr tac diff head dirname seq ip ping \
+		${SAMBA_SRC}/bin/smbpasswd \
+		${SAMBA_SRC}/bin/smbstatus \
+		${SAMBA_SRC}/bin/smbd" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "ceph libceph" \
 	--modules "bash base" \

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -18,15 +18,16 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_local.sh"
 _rt_require_conf_dir SAMBA_SRC
 
-"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.btrfs mkfs.xfs \
-		   stat which touch cut chmod true false \
-		   getfattr setfattr getfacl setfacl killall sync \
-		   id sort uniq date expr tac diff head dirname seq ip ping \
-		   ${SAMBA_SRC}/bin/smbpasswd \
-		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/modules/vfs/btrfs.so \
-		   ${SAMBA_SRC}/bin/smbd" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs mkfs.btrfs mkfs.xfs \
+		stat which touch cut chmod true false \
+		getfattr setfattr getfacl setfacl killall sync \
+		id sort uniq date expr tac diff head dirname seq ip ping \
+		${SAMBA_SRC}/bin/smbpasswd \
+		${SAMBA_SRC}/bin/smbstatus \
+		${SAMBA_SRC}/bin/modules/vfs/btrfs.so \
+		${SAMBA_SRC}/bin/smbd" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle xfs btrfs" \
 	--modules "bash base" \

--- a/cut/simple_example.sh
+++ b/cut/simple_example.sh
@@ -36,8 +36,8 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/simple_example.sh"
 
 # DRACUT_EXTRA_ARGS in rapido.conf allows for extra custom Dracut parameters for
 # debugging, etc.
-"$DRACUT" \
-	--install "resize ps rmdir dd mkfs.xfs" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		resize ps rmdir dd mkfs.xfs" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
 	--modules "bash base" \

--- a/cut/tcmu_rbd_loop.sh
+++ b/cut/tcmu_rbd_loop.sh
@@ -21,14 +21,15 @@ _rt_require_ceph
 # NSS_InitContext() fails without the following...
 _rt_require_lib "libsoftokn3.so libfreeblpriv3.so"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs mkfs.btrfs sync dirname uuidgen ip ping \
-		   ${CEPH_SRC}/build/lib/librbd.so \
-		   ${CEPH_SRC}/build/lib/libceph-common.so \
-		   ${CEPH_SRC}/build/lib/librados.so \
-		   ${TCMU_RUNNER_SRC}/tcmu-runner \
-		   ${TCMU_RUNNER_SRC}/handler_rbd.so \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		strace mkfs.xfs mkfs.btrfs sync dirname uuidgen ip ping \
+		${CEPH_SRC}/build/lib/librbd.so \
+		${CEPH_SRC}/build/lib/libceph-common.so \
+		${CEPH_SRC}/build/lib/librados.so \
+		${TCMU_RUNNER_SRC}/tcmu-runner \
+		${TCMU_RUNNER_SRC}/handler_rbd.so \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \

--- a/cut/tgt_local.sh
+++ b/cut/tgt_local.sh
@@ -18,10 +18,10 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "${RAPIDO_DIR}/autorun/tgt_local.sh"
 _rt_require_conf_dir TGT_SRC
 
-"$DRACUT" \
-	--install "grep ps ip ping \
-		   ${TGT_SRC}/usr/tgtd \
-		   ${TGT_SRC}/usr/tgtadm" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		grep ps ip ping \
+		${TGT_SRC}/usr/tgtd \
+		${TGT_SRC}/usr/tgtadm" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
 	--modules "bash base" \

--- a/cut/usb_rbd.sh
+++ b/cut/usb_rbd.sh
@@ -19,13 +19,14 @@ _rt_require_ceph
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/usb_rbd.sh"
 _rt_require_lib "libkeyutils.so.1"
 
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   eject strace mkfs.vfat mountpoint \
-		   mktemp touch sync cryptsetup dmsetup scp ssh ip ping \
-		   /usr/lib/udev/rules.d/10-dm.rules \
-		   /usr/lib/udev/rules.d/13-dm-disk.rules \
-		   /usr/lib/udev/rules.d/95-dm-notify.rules \
-		   $LIBS_INSTALL_LIST" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		eject strace mkfs.vfat mountpoint \
+		mktemp touch sync cryptsetup dmsetup scp ssh ip ping \
+		/usr/lib/udev/rules.d/10-dm.rules \
+		/usr/lib/udev/rules.d/13-dm-disk.rules \
+		/usr/lib/udev/rules.d/95-dm-notify.rules \
+		$LIBS_INSTALL_LIST" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/zonefstests_nullblk.sh
+++ b/cut/zonefstests_nullblk.sh
@@ -18,9 +18,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_nullblk.sh"
 _rt_require_conf_dir ZONEFSTOOLS_SRC
 
-"$DRACUT" \
-	--install "ps rmdir dd id basename stat wc grep blkzone cut fio \
-		   rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		ps rmdir dd id basename stat wc grep blkzone cut fio \
+		rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "null_blk zonefs" \

--- a/cut/zonefstests_scsi.sh
+++ b/cut/zonefstests_scsi.sh
@@ -18,9 +18,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_scsi.sh"
 _rt_require_conf_dir ZONEFSTOOLS_SRC
 
-"$DRACUT" \
-	--install "ps rmdir dd id basename stat wc grep blkzone cut fio \
-		   rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
+"$DRACUT" --install "$DRACUT_RAPIDO_INSTALL \
+		ps rmdir dd id basename stat wc grep blkzone cut fio \
+		rm truncate ${ZONEFSTOOLS_SRC}/src/mkzonefs" \
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "scsi_debug zonefs" \

--- a/doc/ceph_vstart_kernel_client_guide.adoc
+++ b/doc/ceph_vstart_kernel_client_guide.adoc
@@ -46,7 +46,7 @@ sudo tools/br_setup.sh
 # + created tap1
 --------------
 <1> The device name and address are configured in 'rapido.conf' via
-    'BR_DEV' and 'BR_ADDR' respectively
+    'BR1_DEV' and 'BR_ADDR' respectively
 <2> The 'TAP_USER' 'rapido.conf' parameter specifies the owner of the
     TAP interfaces. This should correspond to the user running Ceph.
 

--- a/doc/ceph_vstart_kernel_client_guide.adoc
+++ b/doc/ceph_vstart_kernel_client_guide.adoc
@@ -46,7 +46,7 @@ sudo tools/br_setup.sh
 # + created tap1
 --------------
 <1> The device name and address are configured in 'rapido.conf' via
-    'BR1_DEV' and 'BR_ADDR' respectively
+    'BR1_DEV' and 'BR1_ADDR' respectively
 <2> The 'TAP_USER' 'rapido.conf' parameter specifies the owner of the
     TAP interfaces. This should correspond to the user running Ceph.
 
@@ -71,7 +71,7 @@ OSD=3 MON=1 RGW=0 MDS=1 ../src/vstart.sh -i 192.168.155.1 -n	# <3>
 <1> Include 'rapido.conf' for 'CEPH_SRC' definition, etc.
 <2> See http://docs.ceph.com/docs/master/install/build-ceph/ for help
     with building Ceph
-<3> The IP address should match the bridge interface address 'BR_ADDR'
+<3> The IP address should match the bridge interface address 'BR1_ADDR'
     defined in 'rapido.conf'.
     A '--memstore' parameter can optionally be added to the 'vstart.sh'
     invocation if memory backed OSDs are desired.

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -103,6 +103,10 @@ VM1_MAC_ADDR1=""
 # IP address assigned to the VM during boot
 VM1_IP_ADDR1="192.168.155.101"
 
+# If defined, second tap tunnel interface provisioned by br_setup.sh,
+# used by vm.sh, and connected to the second bridge device (BR2_DEV).
+#VM1_TAP_DEV2="tap2"
+
 # Static hostname assigned to the VM
 VM1_HOSTNAME="rapido1"
 #############################
@@ -120,6 +124,10 @@ VM2_MAC_ADDR1=""
 
 # Static IP address assigned to the VM during boot
 VM2_IP_ADDR1="192.168.155.102"
+
+# If defined, second tap tunnel interface provisioned by br_setup.sh,
+# used by vm.sh, and connected to the second bridge device (BR2_DEV).
+#VM2_TAP_DEV2="tap3"
 
 # Static hostname assigned to the VM
 VM2_HOSTNAME="rapido2"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -19,14 +19,32 @@ BR1_DEV="rapido-br"
 # created by libvirt, to talk to other VMs.
 #BR1_DEV_SKIP_PROVISON="1"
 
+# If defined, a second bridge device provisioned by "rapido setup-network"
+# (br_setup.sh).
+#BR2_DEV=""
+
+# If defined, the second bridge device provision will be skipped. Use it when
+# you want to connect the vm to an already existing bridge, for example,
+# created by libvirt, to talk to other VMs.
+#BR2_DEV_SKIP_PROVISON="1"
+
 # If specified, a physical network interface to be connected to the bridge.
 # This should only be necessary if you wish to connect to the rapido VMs from a
 # remote host.
 # e.g. BR1_IF="eth0"
 #BR1_IF=""
 
+# If specified, a physical network interface to be connected to the bridge.
+# This should only be necessary if you wish to connect to the rapido VMs from a
+# remote host.
+# e.g. BR1_IF="eth0"
+#BR2_IF=""
+
 # if specified, an address to configure for the bridge device
 BR1_ADDR="192.168.155.1/24"
+
+# if specified, an address to configure for the bridge device
+#BR2_ADDR="192.168.160.1/24"
 
 # if specified, start a dhcp server, listening on $BR1_DEV
 # e.g. BR1_DHCP_SRV_RANGE="192.168.155.10,192.168.155.20,12h"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -71,7 +71,7 @@ QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 VM1_TAP_DEV1="tap0"
 
 # MAC address assigned to the VM
-# e.g. VM1_MAC_ADDR1="b8:ac:24:45:c5:01"
+# e.g. VM1_MAC_ADDR1="b8:ac:24:45:01:01"
 VM1_MAC_ADDR1=""
 
 # When set to "1", use DHCP to obtain IP and hostname.
@@ -89,7 +89,7 @@ VM1_HOSTNAME="rapido1"
 VM2_TAP_DEV1="tap1"
 
 # MAC address assigned to the VM
-# e.g. VM2_MAC_ADDR1="b8:ac:24:45:c5:02"
+# e.g. VM2_MAC_ADDR1="b8:ac:24:45:02:01"
 VM2_MAC_ADDR1=""
 
 # When set to "1", use DHCP to obtain IP and hostname.

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -89,8 +89,8 @@ HOSTNAME1="rapido1"
 TAP_DEV1="tap1"
 
 # MAC address assigned to the VM
-# e.g. MAC_ADDR2="b8:ac:24:45:c5:02"
-MAC_ADDR2=""
+# e.g. VM2_MAC_ADDR1="b8:ac:24:45:c5:02"
+VM2_MAC_ADDR1=""
 
 # When set to "1", use DHCP to obtain IP and hostname.
 #IP_ADDR2_DHCP="1"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -81,7 +81,7 @@ VM1_MAC_ADDR1=""
 VM1_IP_ADDR1="192.168.155.101"
 
 # Static hostname assigned to the VM
-HOSTNAME1="rapido1"
+VM1_HOSTNAME="rapido1"
 #############################
 
 ######### Second VM #########
@@ -99,7 +99,7 @@ VM2_MAC_ADDR1=""
 VM2_IP_ADDR1="192.168.155.102"
 
 # Static hostname assigned to the VM
-HOSTNAME2="rapido2"
+VM2_HOSTNAME="rapido2"
 #############################
 
 ##### Ceph globals #####

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -14,6 +14,11 @@ KERNEL_INSTALL_MOD_PATH="${KERNEL_SRC}/mods"
 # bridge device provisioned by "rapido setup-network" (br_setup.sh).
 BR1_DEV="rapido-br"
 
+# If defined, the first bridge device provision will be skipped. Use it when
+# you want to connect the vm to an already existing bridge, for example,
+# created by libvirt, to talk to other VMs.
+#BR1_DEV_SKIP_PROVISON="1"
+
 # If specified, a physical network interface to be connected to the bridge.
 # This should only be necessary if you wish to connect to the rapido VMs from a
 # remote host.

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -68,7 +68,7 @@ QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 
 ######### First VM #########
 # Tap tunnel interface provisioned by br_setup.sh, and used by vm.sh
-TAP_DEV0="tap0"
+VM1_TAP_DEV1="tap0"
 
 # MAC address assigned to the VM
 # e.g. VM1_MAC_ADDR1="b8:ac:24:45:c5:01"
@@ -86,7 +86,7 @@ VM1_HOSTNAME="rapido1"
 
 ######### Second VM #########
 # Tap tunnel interface provisioned by br_setup.sh, and used by vm.sh
-TAP_DEV1="tap1"
+VM2_TAP_DEV1="tap1"
 
 # MAC address assigned to the VM
 # e.g. VM2_MAC_ADDR1="b8:ac:24:45:c5:02"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -71,8 +71,8 @@ QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 TAP_DEV0="tap0"
 
 # MAC address assigned to the VM
-# e.g. MAC_ADDR1="b8:ac:24:45:c5:01"
-MAC_ADDR1=""
+# e.g. VM1_MAC_ADDR1="b8:ac:24:45:c5:01"
+VM1_MAC_ADDR1=""
 
 # When set to "1", use DHCP to obtain IP and hostname.
 #IP_ADDR1_DHCP="1"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -93,7 +93,7 @@ TAP_DEV1="tap1"
 VM2_MAC_ADDR1=""
 
 # When set to "1", use DHCP to obtain IP and hostname.
-#IP_ADDR2_DHCP="1"
+#VM2_IP_ADDR1_DHCP="1"
 
 # Static IP address assigned to the VM during boot
 VM2_IP_ADDR1="192.168.155.102"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -17,8 +17,8 @@ BR1_DEV="rapido-br"
 # If specified, a physical network interface to be connected to the bridge.
 # This should only be necessary if you wish to connect to the rapido VMs from a
 # remote host.
-# e.g. BR_IF="eth0"
-#BR_IF=""
+# e.g. BR1_IF="eth0"
+#BR1_IF=""
 
 # if specified, an address to configure for the bridge device
 BR1_ADDR="192.168.155.1/24"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -96,7 +96,7 @@ VM2_MAC_ADDR1=""
 #IP_ADDR2_DHCP="1"
 
 # Static IP address assigned to the VM during boot
-IP_ADDR2="192.168.155.102"
+VM2_IP_ADDR1="192.168.155.102"
 
 # Static hostname assigned to the VM
 HOSTNAME2="rapido2"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -78,7 +78,7 @@ VM1_MAC_ADDR1=""
 #IP_ADDR1_DHCP="1"
 
 # IP address assigned to the VM during boot
-IP_ADDR1="192.168.155.101"
+VM1_IP_ADDR1="192.168.155.101"
 
 # Static hostname assigned to the VM
 HOSTNAME1="rapido1"
@@ -265,5 +265,5 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 
 ######## autorun/nvme_tcp_initiator.sh ########
 # NVMe over TCP target details used for mapping
-#NVME_TARGET_TCP="$IP_ADDR1"
+#NVME_TARGET_TCP="$VM1_IP_ADDR1"
 ###############################################

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -12,7 +12,7 @@ KERNEL_SRC=""
 KERNEL_INSTALL_MOD_PATH="${KERNEL_SRC}/mods"
 
 # bridge device provisioned by "rapido setup-network" (br_setup.sh).
-BR_DEV="rapido-br"
+BR1_DEV="rapido-br"
 
 # If specified, a physical network interface to be connected to the bridge.
 # This should only be necessary if you wish to connect to the rapido VMs from a
@@ -23,7 +23,7 @@ BR_DEV="rapido-br"
 # if specified, an address to configure for the bridge device
 BR_ADDR="192.168.155.1/24"
 
-# if specified, start a dhcp server, listening on $BR_DEV
+# if specified, start a dhcp server, listening on $BR1_DEV
 # e.g. BR_DHCP_SRV_RANGE="192.168.155.10,192.168.155.20,12h"
 #BR_DHCP_SRV_RANGE=""
 

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -24,8 +24,8 @@ BR1_DEV="rapido-br"
 BR1_ADDR="192.168.155.1/24"
 
 # if specified, start a dhcp server, listening on $BR1_DEV
-# e.g. BR_DHCP_SRV_RANGE="192.168.155.10,192.168.155.20,12h"
-#BR_DHCP_SRV_RANGE=""
+# e.g. BR1_DHCP_SRV_RANGE="192.168.155.10,192.168.155.20,12h"
+#BR1_DHCP_SRV_RANGE=""
 
 # Tap VM network device owner
 # e.g. TAP_USER="me"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -75,7 +75,7 @@ TAP_DEV0="tap0"
 VM1_MAC_ADDR1=""
 
 # When set to "1", use DHCP to obtain IP and hostname.
-#IP_ADDR1_DHCP="1"
+#VM1_IP_ADDR1_DHCP="1"
 
 # IP address assigned to the VM during boot
 VM1_IP_ADDR1="192.168.155.101"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -21,7 +21,7 @@ BR1_DEV="rapido-br"
 #BR_IF=""
 
 # if specified, an address to configure for the bridge device
-BR_ADDR="192.168.155.1/24"
+BR1_ADDR="192.168.155.1/24"
 
 # if specified, start a dhcp server, listening on $BR1_DEV
 # e.g. BR_DHCP_SRV_RANGE="192.168.155.10,192.168.155.20,12h"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -50,6 +50,10 @@ BR1_ADDR="192.168.155.1/24"
 # e.g. BR1_DHCP_SRV_RANGE="192.168.155.10,192.168.155.20,12h"
 #BR1_DHCP_SRV_RANGE=""
 
+# if specified, start a dhcp server, listening on $BR1_DEV
+# e.g. BR1_DHCP_SRV_RANGE="192.168.160.10,192.168.160.20,12h"
+#BR2_DHCP_SRV_RANGE=""
+
 # Tap VM network device owner
 # e.g. TAP_USER="me"
 TAP_USER=""

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -107,6 +107,16 @@ VM1_IP_ADDR1="192.168.155.101"
 # used by vm.sh, and connected to the second bridge device (BR2_DEV).
 #VM1_TAP_DEV2="tap2"
 
+# MAC address assigned to the VM
+# e.g. VM1_MAC_ADDR1="b8:ac:24:45:01:02"
+#VM1_MAC_ADDR2=""
+
+# When set to "1", use DHCP to obtain IP and hostname.
+#VM1_IP_ADDR2_DHCP="1"
+
+# IP address assigned to the VM during boot
+#VM1_IP_ADDR2="192.168.160.101"
+
 # Static hostname assigned to the VM
 VM1_HOSTNAME="rapido1"
 #############################
@@ -128,6 +138,16 @@ VM2_IP_ADDR1="192.168.155.102"
 # If defined, second tap tunnel interface provisioned by br_setup.sh,
 # used by vm.sh, and connected to the second bridge device (BR2_DEV).
 #VM2_TAP_DEV2="tap3"
+
+# MAC address assigned to the VM
+# e.g. VM2_MAC_ADDR1="b8:ac:24:45:02:02"
+#VM2_MAC_ADDR2=""
+
+# When set to "1", use DHCP to obtain IP and hostname.
+#VM2_IP_ADDR2_DHCP="1"
+
+# Static IP address assigned to the VM during boot
+#VM2_IP_ADDR2="192.168.160.102"
 
 # Static hostname assigned to the VM
 VM2_HOSTNAME="rapido2"

--- a/runtime.vars
+++ b/runtime.vars
@@ -237,6 +237,13 @@ _rt_require_dracut_args() {
 
 	# Core binaries
 	DRACUT_RAPIDO_INSTALL=""
+	for i in $(seq 1 2); do
+		eval local ip_addr1_is_dhcp='$VM'${i}'_IP_ADDR1_DHCP'
+		if [ -n "$ip_addr1_is_dhcp" ]; then
+			DRACUT_RAPIDO_INSTALL="$DRACUT_RAPIDO_INSTALL dhclient dhclient-script"
+			break
+		fi
+	done
 }
 
 _rt_require_qemu_args() {

--- a/runtime.vars
+++ b/runtime.vars
@@ -239,7 +239,8 @@ _rt_require_dracut_args() {
 	DRACUT_RAPIDO_INSTALL=""
 	for i in $(seq 1 2); do
 		eval local ip_addr1_is_dhcp='$VM'${i}'_IP_ADDR1_DHCP'
-		if [ -n "$ip_addr1_is_dhcp" ]; then
+		eval local ip_addr2_is_dhcp='$VM'${i}'_IP_ADDR2_DHCP'
+		if [ -n "$ip_addr1_is_dhcp" ] || [ -n "$ip_addr2_is_dhcp" ]; then
 			DRACUT_RAPIDO_INSTALL="$DRACUT_RAPIDO_INSTALL dhclient dhclient-script"
 			break
 		fi

--- a/runtime.vars
+++ b/runtime.vars
@@ -234,6 +234,9 @@ _rt_require_dracut_args() {
 	fi
 
 	DRACUT_EXTRA_ARGS="$DRACUT_EXTRA_ARGS $dracut_args"
+
+	# Core binaries
+	DRACUT_RAPIDO_INSTALL=""
 }
 
 _rt_require_qemu_args() {

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_conf_setting BR1_DEV TAP_USER TAP_DEV0 TAP_DEV1
+_rt_require_conf_setting BR1_DEV TAP_USER VM1_TAP_DEV1 VM2_TAP_DEV1
 
 # cleanup on premature exit by executing whatever has been prepended to @unwind
 unwind=""
@@ -38,24 +38,24 @@ fi
 echo
 
 # setup tap interfaces for VMs
-ip tuntap add dev $TAP_DEV0 mode tap user $TAP_USER || exit 1
-unwind="ip tuntap delete dev $TAP_DEV0 mode tap; ${unwind}"
-ip link set $TAP_DEV0 master $BR1_DEV || exit 1
-unwind="ip link set $TAP_DEV0 nomaster; ${unwind}"
-echo "+ created $TAP_DEV0"
+ip tuntap add dev $VM1_TAP_DEV1 mode tap user $TAP_USER || exit 1
+unwind="ip tuntap delete dev $VM1_TAP_DEV1 mode tap; ${unwind}"
+ip link set $VM1_TAP_DEV1 master $BR1_DEV || exit 1
+unwind="ip link set $VM1_TAP_DEV1 nomaster; ${unwind}"
+echo "+ created $VM1_TAP_DEV1"
 
-ip tuntap add dev $TAP_DEV1 mode tap user $TAP_USER || exit 1
-unwind="ip tuntap delete dev $TAP_DEV1 mode tap; ${unwind}"
-ip link set $TAP_DEV1 master $BR1_DEV || exit 1
-unwind="ip link set $TAP_DEV1 nomaster; ${unwind}"
-echo "+ created $TAP_DEV1"
+ip tuntap add dev $VM2_TAP_DEV1 mode tap user $TAP_USER || exit 1
+unwind="ip tuntap delete dev $VM2_TAP_DEV1 mode tap; ${unwind}"
+ip link set $VM2_TAP_DEV1 master $BR1_DEV || exit 1
+unwind="ip link set $VM2_TAP_DEV1 nomaster; ${unwind}"
+echo "+ created $VM2_TAP_DEV1"
 
 ip link set dev $BR1_DEV up || exit 1
 unwind="ip link set dev $BR1_DEV down; ${unwind}"
-ip link set dev $TAP_DEV0 up || exit 1
-unwind="ip link set dev $TAP_DEV0 down; ${unwind}"
-ip link set dev $TAP_DEV1 up || exit 1
-unwind="ip link set dev $TAP_DEV1 down; ${unwind}"
+ip link set dev $VM1_TAP_DEV1 up || exit 1
+unwind="ip link set dev $VM1_TAP_DEV1 down; ${unwind}"
+ip link set dev $VM2_TAP_DEV1 up || exit 1
+unwind="ip link set dev $VM2_TAP_DEV1 down; ${unwind}"
 
 if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	hosts=

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -62,7 +62,7 @@ if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	[ -n "$IP_ADDR1" ] && \
 		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR1,$IP_ADDR1,${HOSTNAME1:-vm1}"
 	[ -n "$IP_ADDR2" ] && \
-		hosts="$hosts --dhcp-host=$MAC_ADDR2,$IP_ADDR2,${HOSTNAME2:-vm2}"
+		hosts="$hosts --dhcp-host=$VM2_MAC_ADDR1,$IP_ADDR2,${HOSTNAME2:-vm2}"
 	dnsmasq --no-hosts --no-resolv \
 		--pid-file=/var/run/rapido-dnsmasq-$$.pid \
 		--bind-interfaces \

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -66,11 +66,35 @@ ip link set $VM1_TAP_DEV1 master $BR1_DEV || exit 1
 unwind="ip link set $VM1_TAP_DEV1 nomaster; ${unwind}"
 echo "+ created $VM1_TAP_DEV1"
 
+if [ -n "$VM1_TAP_DEV2" ]; then
+	if [ -z "$BR2_DEV" ]; then
+		echo "VM1_TAP_DEV2 requires BR2_DEV to be defined"
+		exit 1
+	fi
+	ip tuntap add dev $VM1_TAP_DEV2 mode tap user $TAP_USER || exit 1
+	unwind="ip tuntap delete dev $VM1_TAP_DEV2 mode tap; ${unwind}"
+	ip link set $VM1_TAP_DEV2 master $BR2_DEV || exit 1
+	unwind="ip link set $VM1_TAP_DEV2 nomaster; ${unwind}"
+	echo "+ created $VM1_TAP_DEV2"
+fi
+
 ip tuntap add dev $VM2_TAP_DEV1 mode tap user $TAP_USER || exit 1
 unwind="ip tuntap delete dev $VM2_TAP_DEV1 mode tap; ${unwind}"
 ip link set $VM2_TAP_DEV1 master $BR1_DEV || exit 1
 unwind="ip link set $VM2_TAP_DEV1 nomaster; ${unwind}"
 echo "+ created $VM2_TAP_DEV1"
+
+if [ -n "$VM2_TAP_DEV2" ]; then
+	if [ -z "$BR2_DEV" ]; then
+		echo "VM2_TAP_DEV2 requires BR2_DEV to be defined"
+		exit 1
+	fi
+	ip tuntap add dev $VM2_TAP_DEV2 mode tap user $TAP_USER || exit 1
+	unwind="ip tuntap delete dev $VM2_TAP_DEV2 mode tap; ${unwind}"
+	ip link set $VM2_TAP_DEV2 master $BR2_DEV || exit 1
+	unwind="ip link set $VM2_TAP_DEV2 nomaster; ${unwind}"
+	echo "+ created $VM2_TAP_DEV2"
+fi
 
 if [ -z "$BR1_DEV_SKIP_PROVISON" ]; then
 	ip link set dev $BR1_DEV up || exit 1
@@ -84,8 +108,19 @@ fi
 
 ip link set dev $VM1_TAP_DEV1 up || exit 1
 unwind="ip link set dev $VM1_TAP_DEV1 down; ${unwind}"
+
+if [ -n "$VM1_TAP_DEV2" ]; then
+	ip link set dev $VM1_TAP_DEV2 up || exit 1
+	unwind="ip link set dev $VM1_TAP_DEV2 down; ${unwind}"
+fi
+
 ip link set dev $VM2_TAP_DEV1 up || exit 1
 unwind="ip link set dev $VM2_TAP_DEV1 down; ${unwind}"
+
+if [ -n "$VM2_TAP_DEV2" ]; then
+	ip link set dev $VM2_TAP_DEV2 up || exit 1
+	unwind="ip link set dev $VM2_TAP_DEV2 down; ${unwind}"
+fi
 
 if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	hosts=

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -136,7 +136,24 @@ if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 		--dhcp-range="$BR1_DHCP_SRV_RANGE" \
 		${hosts} || exit 1
 	unwind="kill $(cat /var/run/rapido-dnsmasq-$$.pid); ${unwind}"
-	echo "+ started DHCP server"
+	echo "+ started DHCP server in interface ${BR1_DEV}"
+fi
+
+if [ -n "$BR2_DEV" ] && [ -n "$BR2_DHCP_SRV_RANGE" ]; then
+	hosts=
+	[ -n "$VM1_IP_ADDR2" ] && \
+		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR2,$VM1_IP_ADDR2,${VM1_HOSTNAME:-vm1}"
+	[ -n "$VM2_IP_ADDR2" ] && \
+		hosts="$hosts --dhcp-host=$VM2_MAC_ADDR2,$VM2_IP_ADDR2,${VM2_HOSTNAME:-vm2}"
+	dnsmasq --no-hosts --no-resolv \
+		--pid-file=/var/run/rapido-dnsmasq-$$.pid \
+		--bind-interfaces \
+		--interface="$BR2_DEV" \
+		--except-interface=lo \
+		--dhcp-range="$BR2_DHCP_SRV_RANGE" \
+		${hosts} || exit 1
+	unwind="kill $(cat /var/run/rapido-dnsmasq-$$.pid); ${unwind}"
+	echo "+ started DHCP server in interface ${BR2_DEV}"
 fi
 
 # success! clear unwind

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -57,7 +57,7 @@ unwind="ip link set dev $TAP_DEV0 down; ${unwind}"
 ip link set dev $TAP_DEV1 up || exit 1
 unwind="ip link set dev $TAP_DEV1 down; ${unwind}"
 
-if [ -n "$BR_DHCP_SRV_RANGE" ]; then
+if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	hosts=
 	[ -n "$IP_ADDR1" ] && \
 		hosts="$hosts --dhcp-host=$MAC_ADDR1,$IP_ADDR1,${HOSTNAME1:-vm1}"
@@ -68,7 +68,7 @@ if [ -n "$BR_DHCP_SRV_RANGE" ]; then
 		--bind-interfaces \
 		--interface="$BR1_DEV" \
 		--except-interface=lo \
-		--dhcp-range="$BR_DHCP_SRV_RANGE" \
+		--dhcp-range="$BR1_DHCP_SRV_RANGE" \
 		${hosts} || exit 1
 	unwind="kill $(cat /var/run/rapido-dnsmasq-$$.pid); ${unwind}"
 	echo "+ started DHCP server"

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -61,8 +61,8 @@ if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	hosts=
 	[ -n "$VM1_IP_ADDR1" ] && \
 		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR1,$VM1_IP_ADDR1,${HOSTNAME1:-vm1}"
-	[ -n "$IP_ADDR2" ] && \
-		hosts="$hosts --dhcp-host=$VM2_MAC_ADDR1,$IP_ADDR2,${HOSTNAME2:-vm2}"
+	[ -n "$VM2_IP_ADDR1" ] && \
+		hosts="$hosts --dhcp-host=$VM2_MAC_ADDR1,$VM2_IP_ADDR1,${HOSTNAME2:-vm2}"
 	dnsmasq --no-hosts --no-resolv \
 		--pid-file=/var/run/rapido-dnsmasq-$$.pid \
 		--bind-interfaces \

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -15,23 +15,23 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_conf_setting BR_DEV TAP_USER TAP_DEV0 TAP_DEV1
+_rt_require_conf_setting BR1_DEV TAP_USER TAP_DEV0 TAP_DEV1
 
 # cleanup on premature exit by executing whatever has been prepended to @unwind
 unwind=""
 trap "eval \$unwind" 0 1 2 3 15
 
-ip link add $BR_DEV type bridge || _fail "failed to add $BR_DEV"
-unwind="ip link delete $BR_DEV type bridge; ${unwind}"
-echo -n "+ created bridge $BR_DEV"
+ip link add $BR1_DEV type bridge || _fail "failed to add $BR1_DEV"
+unwind="ip link delete $BR1_DEV type bridge; ${unwind}"
+echo -n "+ created bridge $BR1_DEV"
 if [ -n "$BR_ADDR" ]; then
-	ip addr add $BR_ADDR dev $BR_DEV || exit 1
-	unwind="ip addr del $BR_ADDR dev $BR_DEV; ${unwind}"
+	ip addr add $BR_ADDR dev $BR1_DEV || exit 1
+	unwind="ip addr del $BR_ADDR dev $BR1_DEV; ${unwind}"
 	echo -n " with address $BR_ADDR"
 fi
 
 if [ -n "$BR_IF" ]; then
-	ip link set $BR_IF master $BR_DEV || exit 1
+	ip link set $BR_IF master $BR1_DEV || exit 1
 	unwind="ip link set $BR_IF nomaster; ${unwind}"
 	echo -n ", connected to $BR_IF"
 fi
@@ -40,18 +40,18 @@ echo
 # setup tap interfaces for VMs
 ip tuntap add dev $TAP_DEV0 mode tap user $TAP_USER || exit 1
 unwind="ip tuntap delete dev $TAP_DEV0 mode tap; ${unwind}"
-ip link set $TAP_DEV0 master $BR_DEV || exit 1
+ip link set $TAP_DEV0 master $BR1_DEV || exit 1
 unwind="ip link set $TAP_DEV0 nomaster; ${unwind}"
 echo "+ created $TAP_DEV0"
 
 ip tuntap add dev $TAP_DEV1 mode tap user $TAP_USER || exit 1
 unwind="ip tuntap delete dev $TAP_DEV1 mode tap; ${unwind}"
-ip link set $TAP_DEV1 master $BR_DEV || exit 1
+ip link set $TAP_DEV1 master $BR1_DEV || exit 1
 unwind="ip link set $TAP_DEV1 nomaster; ${unwind}"
 echo "+ created $TAP_DEV1"
 
-ip link set dev $BR_DEV up || exit 1
-unwind="ip link set dev $BR_DEV down; ${unwind}"
+ip link set dev $BR1_DEV up || exit 1
+unwind="ip link set dev $BR1_DEV down; ${unwind}"
 ip link set dev $TAP_DEV0 up || exit 1
 unwind="ip link set dev $TAP_DEV0 down; ${unwind}"
 ip link set dev $TAP_DEV1 up || exit 1
@@ -66,7 +66,7 @@ if [ -n "$BR_DHCP_SRV_RANGE" ]; then
 	dnsmasq --no-hosts --no-resolv \
 		--pid-file=/var/run/rapido-dnsmasq-$$.pid \
 		--bind-interfaces \
-		--interface="$BR_DEV" \
+		--interface="$BR1_DEV" \
 		--except-interface=lo \
 		--dhcp-range="$BR_DHCP_SRV_RANGE" \
 		${hosts} || exit 1

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -60,7 +60,7 @@ unwind="ip link set dev $TAP_DEV1 down; ${unwind}"
 if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	hosts=
 	[ -n "$IP_ADDR1" ] && \
-		hosts="$hosts --dhcp-host=$MAC_ADDR1,$IP_ADDR1,${HOSTNAME1:-vm1}"
+		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR1,$IP_ADDR1,${HOSTNAME1:-vm1}"
 	[ -n "$IP_ADDR2" ] && \
 		hosts="$hosts --dhcp-host=$MAC_ADDR2,$IP_ADDR2,${HOSTNAME2:-vm2}"
 	dnsmasq --no-hosts --no-resolv \

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -30,10 +30,10 @@ if [ -n "$BR1_ADDR" ]; then
 	echo -n " with address $BR1_ADDR"
 fi
 
-if [ -n "$BR_IF" ]; then
-	ip link set $BR_IF master $BR1_DEV || exit 1
-	unwind="ip link set $BR_IF nomaster; ${unwind}"
-	echo -n ", connected to $BR_IF"
+if [ -n "$BR1_IF" ]; then
+	ip link set $BR1_IF master $BR1_DEV || exit 1
+	unwind="ip link set $BR1_IF nomaster; ${unwind}"
+	echo -n ", connected to $BR1_IF"
 fi
 echo
 

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -24,10 +24,10 @@ trap "eval \$unwind" 0 1 2 3 15
 ip link add $BR1_DEV type bridge || _fail "failed to add $BR1_DEV"
 unwind="ip link delete $BR1_DEV type bridge; ${unwind}"
 echo -n "+ created bridge $BR1_DEV"
-if [ -n "$BR_ADDR" ]; then
-	ip addr add $BR_ADDR dev $BR1_DEV || exit 1
-	unwind="ip addr del $BR_ADDR dev $BR1_DEV; ${unwind}"
-	echo -n " with address $BR_ADDR"
+if [ -n "$BR1_ADDR" ]; then
+	ip addr add $BR1_ADDR dev $BR1_DEV || exit 1
+	unwind="ip addr del $BR1_ADDR dev $BR1_DEV; ${unwind}"
+	echo -n " with address $BR1_ADDR"
 fi
 
 if [ -n "$BR_IF" ]; then

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -60,9 +60,9 @@ unwind="ip link set dev $TAP_DEV1 down; ${unwind}"
 if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	hosts=
 	[ -n "$VM1_IP_ADDR1" ] && \
-		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR1,$VM1_IP_ADDR1,${HOSTNAME1:-vm1}"
+		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR1,$VM1_IP_ADDR1,${VM1_HOSTNAME:-vm1}"
 	[ -n "$VM2_IP_ADDR1" ] && \
-		hosts="$hosts --dhcp-host=$VM2_MAC_ADDR1,$VM2_IP_ADDR1,${HOSTNAME2:-vm2}"
+		hosts="$hosts --dhcp-host=$VM2_MAC_ADDR1,$VM2_IP_ADDR1,${VM2_HOSTNAME:-vm2}"
 	dnsmasq --no-hosts --no-resolv \
 		--pid-file=/var/run/rapido-dnsmasq-$$.pid \
 		--bind-interfaces \

--- a/tools/br_setup.sh
+++ b/tools/br_setup.sh
@@ -59,8 +59,8 @@ unwind="ip link set dev $TAP_DEV1 down; ${unwind}"
 
 if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	hosts=
-	[ -n "$IP_ADDR1" ] && \
-		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR1,$IP_ADDR1,${HOSTNAME1:-vm1}"
+	[ -n "$VM1_IP_ADDR1" ] && \
+		hosts="$hosts --dhcp-host=$VM1_MAC_ADDR1,$VM1_IP_ADDR1,${HOSTNAME1:-vm1}"
 	[ -n "$IP_ADDR2" ] && \
 		hosts="$hosts --dhcp-host=$VM2_MAC_ADDR1,$IP_ADDR2,${HOSTNAME2:-vm2}"
 	dnsmasq --no-hosts --no-resolv \

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="`dirname $0`/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_conf_setting BR1_DEV TAP_DEV0 TAP_DEV1
+_rt_require_conf_setting BR1_DEV VM1_TAP_DEV1 VM2_TAP_DEV1
 
 set -x
 
@@ -31,15 +31,15 @@ if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	kill "$dnsmasq_pid"
 fi
 
-ip link set dev $TAP_DEV1 down || exit 1
-ip link set dev $TAP_DEV0 down || exit 1
+ip link set dev $VM2_TAP_DEV1 down || exit 1
+ip link set dev $VM1_TAP_DEV1 down || exit 1
 ip link set dev $BR1_DEV down || exit 1
 
-ip link set $TAP_DEV1 nomaster || exit 1
-ip tuntap delete dev $TAP_DEV1 mode tap || exit 1
+ip link set $VM2_TAP_DEV1 nomaster || exit 1
+ip tuntap delete dev $VM2_TAP_DEV1 mode tap || exit 1
 
-ip link set $TAP_DEV0 nomaster || exit 1
-ip tuntap delete dev $TAP_DEV0 mode tap || exit 1
+ip link set $VM1_TAP_DEV1 nomaster || exit 1
+ip tuntap delete dev $VM1_TAP_DEV1 mode tap || exit 1
 
 if [ -n "$BR1_IF" ]; then
 	ip link set $BR1_IF nomaster || exit 1

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -31,6 +31,18 @@ if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	kill "$dnsmasq_pid"
 fi
 
+if [ -n "$BR2_DEV" ] && [ -n "$BR2_DHCP_SRV_RANGE" ]; then
+	dnsmasq_pid=`ps -eo pid,args | grep -v grep | grep dnsmasq \
+			| grep -- --interface=$BR2_DEV \
+			| grep -- --dhcp-range=$BR2_DHCP_SRV_RANGE \
+			| awk '{print $1}'`
+	if [ -z "$dnsmasq_pid" ]; then
+		echo "failed to find dnsmasq process"
+		exit 1
+	fi
+	kill "$dnsmasq_pid"
+fi
+
 ip link set dev $VM2_TAP_DEV1 down || exit 1
 if [ -n "$VM2_TAP_DEV2" ]; then
 	ip link set dev $VM2_TAP_DEV2 down || exit 1

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -15,13 +15,13 @@
 RAPIDO_DIR="`dirname $0`/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_conf_setting BR_DEV TAP_DEV0 TAP_DEV1
+_rt_require_conf_setting BR1_DEV TAP_DEV0 TAP_DEV1
 
 set -x
 
 if [ -n "$BR_DHCP_SRV_RANGE" ]; then
 	dnsmasq_pid=`ps -eo pid,args | grep -v grep | grep dnsmasq \
-			| grep -- --interface=$BR_DEV \
+			| grep -- --interface=$BR1_DEV \
 			| grep -- --dhcp-range=$BR_DHCP_SRV_RANGE \
 			| awk '{print $1}'`
 	if [ -z "$dnsmasq_pid" ]; then
@@ -33,7 +33,7 @@ fi
 
 ip link set dev $TAP_DEV1 down || exit 1
 ip link set dev $TAP_DEV0 down || exit 1
-ip link set dev $BR_DEV down || exit 1
+ip link set dev $BR1_DEV down || exit 1
 
 ip link set $TAP_DEV1 nomaster || exit 1
 ip tuntap delete dev $TAP_DEV1 mode tap || exit 1
@@ -46,6 +46,6 @@ if [ -n "$BR_IF" ]; then
 fi
 
 if [ -n "$BR_ADDR" ]; then
-	ip addr del $BR_ADDR dev $BR_DEV || exit 1
+	ip addr del $BR_ADDR dev $BR1_DEV || exit 1
 fi
-ip link delete $BR_DEV type bridge || exit 1
+ip link delete $BR1_DEV type bridge || exit 1

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -32,7 +32,13 @@ if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 fi
 
 ip link set dev $VM2_TAP_DEV1 down || exit 1
+if [ -n "$VM2_TAP_DEV2" ]; then
+	ip link set dev $VM2_TAP_DEV2 down || exit 1
+fi
 ip link set dev $VM1_TAP_DEV1 down || exit 1
+if [ -n "$VM1_TAP_DEV2" ]; then
+	ip link set dev $VM1_TAP_DEV2 down || exit 1
+fi
 
 if [ -z "$BR1_DEV_SKIP_PROVISON" ]; then
 	ip link set dev $BR1_DEV down || exit 1
@@ -44,9 +50,17 @@ fi
 
 ip link set $VM2_TAP_DEV1 nomaster || exit 1
 ip tuntap delete dev $VM2_TAP_DEV1 mode tap || exit 1
+if [ -n "$VM2_TAP_DEV2" ]; then
+	ip link set $VM2_TAP_DEV2 nomaster || exit 1
+	ip tuntap delete dev $VM2_TAP_DEV2 mode tap || exit 1
+fi
 
 ip link set $VM1_TAP_DEV1 nomaster || exit 1
 ip tuntap delete dev $VM1_TAP_DEV1 mode tap || exit 1
+if [ -n "$VM1_TAP_DEV2" ]; then
+	ip link set $VM1_TAP_DEV2 nomaster || exit 1
+	ip tuntap delete dev $VM1_TAP_DEV2 mode tap || exit 1
+fi
 
 if [ -z "$BR1_DEV_SKIP_PROVISON" ]; then
 	if [ -n "$BR1_IF" ]; then

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -45,7 +45,7 @@ if [ -n "$BR_IF" ]; then
 	ip link set $BR_IF nomaster || exit 1
 fi
 
-if [ -n "$BR_ADDR" ]; then
-	ip addr del $BR_ADDR dev $BR1_DEV || exit 1
+if [ -n "$BR1_ADDR" ]; then
+	ip addr del $BR1_ADDR dev $BR1_DEV || exit 1
 fi
 ip link delete $BR1_DEV type bridge || exit 1

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -41,8 +41,8 @@ ip tuntap delete dev $TAP_DEV1 mode tap || exit 1
 ip link set $TAP_DEV0 nomaster || exit 1
 ip tuntap delete dev $TAP_DEV0 mode tap || exit 1
 
-if [ -n "$BR_IF" ]; then
-	ip link set $BR_IF nomaster || exit 1
+if [ -n "$BR1_IF" ]; then
+	ip link set $BR1_IF nomaster || exit 1
 fi
 
 if [ -n "$BR1_ADDR" ]; then

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -33,7 +33,10 @@ fi
 
 ip link set dev $VM2_TAP_DEV1 down || exit 1
 ip link set dev $VM1_TAP_DEV1 down || exit 1
-ip link set dev $BR1_DEV down || exit 1
+
+if [ -z "$BR1_DEV_SKIP_PROVISON" ]; then
+	ip link set dev $BR1_DEV down || exit 1
+fi
 
 ip link set $VM2_TAP_DEV1 nomaster || exit 1
 ip tuntap delete dev $VM2_TAP_DEV1 mode tap || exit 1
@@ -41,11 +44,13 @@ ip tuntap delete dev $VM2_TAP_DEV1 mode tap || exit 1
 ip link set $VM1_TAP_DEV1 nomaster || exit 1
 ip tuntap delete dev $VM1_TAP_DEV1 mode tap || exit 1
 
-if [ -n "$BR1_IF" ]; then
-	ip link set $BR1_IF nomaster || exit 1
-fi
+if [ -z "$BR1_DEV_SKIP_PROVISON" ]; then
+	if [ -n "$BR1_IF" ]; then
+		ip link set $BR1_IF nomaster || exit 1
+	fi
 
-if [ -n "$BR1_ADDR" ]; then
-	ip addr del $BR1_ADDR dev $BR1_DEV || exit 1
+	if [ -n "$BR1_ADDR" ]; then
+		ip addr del $BR1_ADDR dev $BR1_DEV || exit 1
+	fi
+	ip link delete $BR1_DEV type bridge || exit 1
 fi
-ip link delete $BR1_DEV type bridge || exit 1

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -38,6 +38,10 @@ if [ -z "$BR1_DEV_SKIP_PROVISON" ]; then
 	ip link set dev $BR1_DEV down || exit 1
 fi
 
+if [ -n "$BR2_DEV" ] && [ -z "$BR2_DEV_SKIP_PROVISON" ]; then
+	ip link set dev $BR2_DEV down || exit 1
+fi
+
 ip link set $VM2_TAP_DEV1 nomaster || exit 1
 ip tuntap delete dev $VM2_TAP_DEV1 mode tap || exit 1
 
@@ -53,4 +57,16 @@ if [ -z "$BR1_DEV_SKIP_PROVISON" ]; then
 		ip addr del $BR1_ADDR dev $BR1_DEV || exit 1
 	fi
 	ip link delete $BR1_DEV type bridge || exit 1
+fi
+
+if [ -n "$BR2_DEV" ] && [ -z "$BR2_DEV_SKIP_PROVISON" ]; then
+	if [ -n "$BR2_IF" ]; then
+		ip link set $BR2_IF nomaster || exit 1
+	fi
+
+	if [ -n "$BR2_ADDR" ]; then
+		ip addr del $BR2_ADDR dev $BR2_DEV || exit 1
+	fi
+	ip link delete $BR2_DEV type bridge || exit 1
+
 fi

--- a/tools/br_teardown.sh
+++ b/tools/br_teardown.sh
@@ -19,10 +19,10 @@ _rt_require_conf_setting BR1_DEV TAP_DEV0 TAP_DEV1
 
 set -x
 
-if [ -n "$BR_DHCP_SRV_RANGE" ]; then
+if [ -n "$BR1_DHCP_SRV_RANGE" ]; then
 	dnsmasq_pid=`ps -eo pid,args | grep -v grep | grep dnsmasq \
 			| grep -- --interface=$BR1_DEV \
-			| grep -- --dhcp-range=$BR_DHCP_SRV_RANGE \
+			| grep -- --dhcp-range=$BR1_DHCP_SRV_RANGE \
 			| awk '{print $1}'`
 	if [ -z "$dnsmasq_pid" ]; then
 		echo "failed to find dnsmasq process"

--- a/tools/setup_br_ip_takeover.sh
+++ b/tools/setup_br_ip_takeover.sh
@@ -12,10 +12,10 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-# This script removes all addresses from $BR_IF, creates $BR_DEV and
-# subsequently adds all previous $BR_IF addresses to the new $BR_DEV.
+# This script removes all addresses from $BR_IF, creates $BR1_DEV and
+# subsequently adds all previous $BR_IF addresses to the new $BR1_DEV.
 # The routing table is also replaced, with all $BR_IF routes transferring
-# to $BR_DEV.
+# to $BR1_DEV.
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
@@ -58,7 +58,7 @@ function _apply_addrs() {
 }
 
 [ -z "$BR_ADDR" ] || _fail "BR_ADDR setting incompatible with ip takeover"
-[ -n "$BR_DEV" ] || _fail "BR_DEV required for IP takeover"
+[ -n "$BR1_DEV" ] || _fail "BR1_DEV required for IP takeover"
 [ -n "$BR_IF" ] || _fail "BR_IF required for IP takeover"
 
 set -x
@@ -87,14 +87,14 @@ _apply_routes del "$BR_IF" "${BR_IF_DUMP_DIR}/routes" || exit 1
 _apply_addrs del "$BR_IF" "${BR_IF_DUMP_DIR}/inet6_addrs" || exit 1
 _apply_addrs del "$BR_IF" "${BR_IF_DUMP_DIR}/inet4_addrs" || exit 1
 
-# use regular bridge setup helper to provision BR_DEV and taps
+# use regular bridge setup helper to provision BR1_DEV and taps
 ${RAPIDO_DIR}/tools/br_setup.sh || exit 1
 unwind="${RAPIDO_DIR}/tools/br_teardown.sh; ${unwind}"
 
-_apply_addrs add "$BR_DEV" "${BR_IF_DUMP_DIR}/inet6_addrs" || exit 1
-_apply_addrs add "$BR_DEV" "${BR_IF_DUMP_DIR}/inet4_addrs" || exit 1
+_apply_addrs add "$BR1_DEV" "${BR_IF_DUMP_DIR}/inet6_addrs" || exit 1
+_apply_addrs add "$BR1_DEV" "${BR_IF_DUMP_DIR}/inet4_addrs" || exit 1
 
-_apply_routes add "$BR_DEV" "${BR_IF_DUMP_DIR}/routes" || exit 1
+_apply_routes add "$BR1_DEV" "${BR_IF_DUMP_DIR}/routes" || exit 1
 
 rm ${BR_IF_DUMP_DIR}/routes ${BR_IF_DUMP_DIR}/*addrs
 rmdir ${BR_IF_DUMP_DIR}

--- a/tools/setup_br_ip_takeover.sh
+++ b/tools/setup_br_ip_takeover.sh
@@ -57,7 +57,7 @@ function _apply_addrs() {
 	done < $addrs_file
 }
 
-[ -z "$BR_ADDR" ] || _fail "BR_ADDR setting incompatible with ip takeover"
+[ -z "$BR1_ADDR" ] || _fail "BR1_ADDR setting incompatible with ip takeover"
 [ -n "$BR1_DEV" ] || _fail "BR1_DEV required for IP takeover"
 [ -n "$BR_IF" ] || _fail "BR_IF required for IP takeover"
 

--- a/vm.sh
+++ b/vm.sh
@@ -50,6 +50,14 @@ function _vm_start
 			|| _fail "VM${vm_num}_TAP_DEV1 not configured"
 		qemu_netdev="-device virtio-net,netdev=nw1,mac=${mac_addr} \
 			-netdev tap,id=nw1,script=no,downscript=no,ifname=${tap}"
+
+		eval local mac_addr='$VM'${vm_num}'_MAC_ADDR2'
+		eval local tap='$VM'${vm_num}'_TAP_DEV2'
+		if [ -n "$mac_addr" ] && [ -n "$tap" ]; then
+			qemu_netdev="$qemu_netdev \
+				-device virtio-net,netdev=nw2,mac=${mac_addr} \
+				-netdev tap,id=nw2,script=no,downscript=no,ifname=${tap}"
+		fi
 	fi
 
 	# cut_ script may have specified some parameters for qemu

--- a/vm.sh
+++ b/vm.sh
@@ -50,7 +50,7 @@ function _vm_start
 		eval local tap='$TAP_DEV'$((vm_num - 1))
 		[ -n "$tap" ] \
 			|| _fail "TAP_DEV$((vm_num - 1)) not configured"
-		eval local is_dhcp='$IP_ADDR'${vm_num}'_DHCP'
+		eval local is_dhcp='$VM'${vm_num}'_IP_ADDR1_DHCP'
 		if [ "$is_dhcp" = "1" ]; then
 			kern_ip_addr="dhcp"
 		else

--- a/vm.sh
+++ b/vm.sh
@@ -54,9 +54,9 @@ function _vm_start
 		if [ "$is_dhcp" = "1" ]; then
 			kern_ip_addr="dhcp"
 		else
-			eval local hostname='$HOSTNAME'${vm_num}
+			eval local hostname='$VM'${vm_num}'_HOSTNAME'
 			[ -n "$hostname" ] \
-				|| _fail "HOSTNAME${vm_num} not configured"
+				|| _fail "VM${vm_num}_HOSTNAME not configured"
 			eval local ip_addr='$VM'${vm_num}'_IP_ADDR1'
 			[ -n "$ip_addr" ] \
 				|| _fail "VM${vm_num}_IP_ADDR1 not configured"

--- a/vm.sh
+++ b/vm.sh
@@ -47,9 +47,9 @@ function _vm_start
 		qemu_netdev="-net none"	# override default (-net nic -net user)
 	else
 		eval local mac_addr='$VM'${vm_num}'_MAC_ADDR1'
-		eval local tap='$TAP_DEV'$((vm_num - 1))
+		eval local tap='$VM'${vm_num}'_TAP_DEV1'
 		[ -n "$tap" ] \
-			|| _fail "TAP_DEV$((vm_num - 1)) not configured"
+			|| _fail "VM${vm_num}_TAP_DEV1 not configured"
 		eval local is_dhcp='$VM'${vm_num}'_IP_ADDR1_DHCP'
 		if [ "$is_dhcp" = "1" ]; then
 			kern_ip_addr="dhcp"

--- a/vm.sh
+++ b/vm.sh
@@ -57,9 +57,9 @@ function _vm_start
 			eval local hostname='$HOSTNAME'${vm_num}
 			[ -n "$hostname" ] \
 				|| _fail "HOSTNAME${vm_num} not configured"
-			eval local ip_addr='$IP_ADDR'${vm_num}
+			eval local ip_addr='$VM'${vm_num}'_IP_ADDR1'
 			[ -n "$ip_addr" ] \
-				|| _fail "IP_ADDR${vm_num} not configured"
+				|| _fail "VM${vm_num}_IP_ADDR1 not configured"
 			kern_ip_addr="${ip_addr}:::255.255.255.0:${hostname}"
 		fi
 		qemu_netdev="-device virtio-net,netdev=nw1,mac=${mac_addr} \

--- a/vm.sh
+++ b/vm.sh
@@ -39,8 +39,6 @@ function _vm_start
 		_fail "a maximum of two network connected VMs are supported"
 	fi
 
-	# XXX rapido.conf VM parameters are pretty inconsistent and confusing
-	# moving to a VM${vm_num}_MAC_ADDR or ini style config would make sense
 	local qemu_netdev=""
 	local kern_ip_addr=""
 	if [ -n "$(_rt_xattr_vm_networkless_get ${DRACUT_OUT})" ]; then
@@ -48,7 +46,7 @@ function _vm_start
 		kern_ip_addr="none"
 		qemu_netdev="-net none"	# override default (-net nic -net user)
 	else
-		eval local mac_addr='$MAC_ADDR'${vm_num}
+		eval local mac_addr='$VM'${vm_num}'_MAC_ADDR1'
 		eval local tap='$TAP_DEV'$((vm_num - 1))
 		[ -n "$tap" ] \
 			|| _fail "TAP_DEV$((vm_num - 1)) not configured"

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -80,11 +80,11 @@ function _vm_kcli_param_get()
 function _vm_ar_hostname_set
 {
 	# networkless VM, so get the rapido.vm_num value from the kernel command
-	# line and use HOSTNAME<vm_num> configured in rapido.conf
+	# line and use VM<vm_num>_HOSTNAME configured in rapido.conf
 	_vm_kcli_param_get "rapido.vm_num"
 	[ -z "$kcli_rapido_vm_num" ] && _fatal "rapido.vm_num missing in kcli"
 
-	eval local hostname='$HOSTNAME'${kcli_rapido_vm_num}
+	eval local hostname='$VM'${kcli_rapido_vm_num}'_HOSTNAME'
 	[ -z "$hostname" ] && hostname="rapido${kcli_rapido_vm_num}"
 	echo $hostname > /proc/sys/kernel/hostname \
 		|| _fatal "failed to set hostname"

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -151,10 +151,27 @@ function _vm_ar_rbd_map
 	_fatal
 }
 
-if [[ "$(cat /proc/cmdline)" == *"ip=none"* ]]; then
-	# networkless VM - set hostname manually
-	_vm_ar_hostname_set
-fi
+function _vm_ar_setup_network
+{
+	_vm_kcli_param_get "rapido.vm_num"
+	[ -z "$kcli_rapido_vm_num" ] && _fatal "rapido.vm_num missing in kcli"
+
+	eval local ip_addr1_is_dhcp='$VM'${kcli_rapido_vm_num}'_IP_ADDR1_DHCP'
+	if [ -z "$ip_addr1_is_dhcp" ]; then
+		eval local ip_addr1='$VM'${kcli_rapido_vm_num}'_IP_ADDR1'
+		[ -z "$ip_addr1" ] && _fatal "VM${kcli_rapido_vm_num}_IP_ADDR1 not configured"
+		ip link set eth0 up
+		ip addr add $ip_addr1/24 dev eth0
+	else
+		[ -d "/var/lib/dhcp" ] || mkdir -p /var/lib/dhcp/
+		ip link set eth0 up
+		dhclient -v eth0
+	fi
+}
+
+_vm_ar_hostname_set
+_vm_ar_setup_network
+
 export TERM="linux"
 export PS1="$(cat /proc/sys/kernel/hostname):\${PWD}# "
 resize &> /dev/null

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -167,6 +167,20 @@ function _vm_ar_setup_network
 		ip link set eth0 up
 		dhclient -v eth0
 	fi
+
+	# Second interface is optional
+	eval local ip_addr2_is_dhcp='$VM'${kcli_rapido_vm_num}'_IP_ADDR2_DHCP'
+	if [ -z "$ip_addr2_is_dhcp" ]; then
+		eval local ip_addr2='$VM'${kcli_rapido_vm_num}'_IP_ADDR2'
+		if [ -n "$ip_addr2" ]; then
+			ip addr add $ip_addr2/24 dev eth1
+			ip link set eth1 up
+		fi
+	else
+		[ -d "/var/lib/dhcp" ] || mkdir -p /var/lib/dhcp/
+		ip link set eth1 up
+		dhclient -v eth1
+	fi
 }
 
 _vm_ar_hostname_set


### PR DESCRIPTION
Changes:

* Rename configuration variables to use `BRx_` and `VMx_` as prefix
* Allow to skip the bridge device provision with `BRx_DEV_SKIP_PROVISION`, useful to reuse the bridge devices created by libvirt and connect the rapido VMs to them
* Allow to create a second network adapter in each VM, connected to the second bridge device `BR2_DEV`.
* Setup the network in `vm_autorun.env` instead of using the `ip=` kernel parameter. It will allow to use IPv6 addresses in the future.