### PR TITLE
support post-autorun scripts via rapido cut -f <script> and -x <command> parameters

### DIFF
--- a/cut/blktests_rbd.sh
+++ b/cut/blktests_rbd.sh
@@ -19,7 +19,8 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/blktests_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/blktests_rbd.sh" \
+			"$@"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_blktests

--- a/cut/blktests_zram.sh
+++ b/cut/blktests_zram.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/blktests_zram.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/blktests_zram.sh" "$@"
 _rt_require_blktests
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/cephfs.sh
+++ b/cut/cephfs.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs.sh" "$@"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace stat which touch cut chmod true false \

--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -22,7 +22,8 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_write_ceph_bin_paths $vm_ceph_conf
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs_fuse.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs_fuse.sh" \
+			"$@"
 _rt_require_lib "libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 

--- a/cut/cifs.sh
+++ b/cut/cifs.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/cifs.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/cifs.sh" "$@"
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
 		   mount.cifs ip ping getfacl setfacl truncate du \

--- a/cut/ctdb_cephfs.sh
+++ b/cut/ctdb_cephfs.sh
@@ -22,7 +22,8 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_samba_ctdb
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/ctdb_cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/ctdb_cephfs.sh" \
+			"$@"
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 

--- a/cut/dropbear.sh
+++ b/cut/dropbear.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/dropbear.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/dropbear.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/fcoe_local.sh
+++ b/cut/fcoe_local.sh
@@ -14,7 +14,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/fcoe_local.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fcoe_local.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs.sh" "$@"
 _rt_require_fstests
 _rt_require_btrfs_progs
 

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -19,7 +19,8 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/fstests_cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" \
+			"$RAPIDO_DIR/autorun/fstests_cephfs.sh" "$@"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_fstests

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cifs.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cifs.sh" "$@"
 _rt_require_fstests
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_xfs.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_xfs.sh" "$@"
 _rt_require_fstests
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/lio_local.sh
+++ b/cut/lio_local.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_local.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_local.sh" "$@"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs truncate losetup dmsetup \

--- a/cut/lio_pscsi_loop.sh
+++ b/cut/lio_pscsi_loop.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "${RAPIDO_DIR}/autorun/lio_pscsi_loop.sh"
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/lio_pscsi_loop.sh" "$@"
 
 # the pscsi VM should be booted with a virtio SCSI device attached. E.g.
 # QEMU_EXTRA_ARGS="-nographic -device virtio-scsi-pci,id=scsi \

--- a/cut/lio_rbd.sh
+++ b/cut/lio_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lio_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lio_rbd.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/lrbd.sh
+++ b/cut/lrbd.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/lrbd.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lrbd.sh" "$@"
 _rt_require_ceph
 _rt_require_conf_dir LRBD_SRC TARGETCLI_SRC RTSLIB_SRC CONFIGSHELL_SRC
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \

--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/ltp.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/ltp.sh" "$@"
 _rt_require_conf_dir LTP_DIR
 
 "$DRACUT" \

--- a/cut/mpath_local.sh
+++ b/cut/mpath_local.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/mpath_local.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/mpath_local.sh" "$@"
 
 # the VM should be deployed with two virtio SCSI devices which share the same
 # backing <file> and <serial> parameters. E.g.

--- a/cut/nvme_local.sh
+++ b/cut/nvme_local.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_local.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_local.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/nvme_rbd.sh
+++ b/cut/nvme_rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_rbd.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/nvme_rdma.sh
+++ b/cut/nvme_rdma.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rdma.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rdma.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/nvme_tcp_initiator.sh
+++ b/cut/nvme_tcp_initiator.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_tcp_initiator.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_tcp_initiator.sh" "$@"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs ip ping" \

--- a/cut/nvme_tcp_rbd.sh
+++ b/cut/nvme_tcp_rbd.sh
@@ -21,7 +21,8 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/nvme_tcp_rbd.sh" \
+			"$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/openiscsi.sh
+++ b/cut/openiscsi.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "${RAPIDO_DIR}/autorun/openiscsi.sh"
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/openiscsi.sh" "$@"
 _rt_require_conf_dir OPENISCSI_SRC
 
 "$DRACUT" \

--- a/cut/rbd.sh
+++ b/cut/rbd.sh
@@ -21,7 +21,7 @@ trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/rbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/rbd.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/rbd_nbd.sh
+++ b/cut/rbd_nbd.sh
@@ -19,7 +19,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/rbd_nbd.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/rbd_nbd.sh" "$@"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_lib "libsoftokn3.so libsqlite3.so \

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -19,7 +19,8 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/samba_cephfs.sh"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/samba_cephfs.sh" \
+			"$@"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -20,7 +20,7 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
 _rt_require_dracut_args "$vm_ceph_conf" \
-			"$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh"
+			"$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh" "$@"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_conf_dir SAMBA_SRC

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_local.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_local.sh" "$@"
 _rt_require_conf_dir SAMBA_SRC
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/simple_example.sh
+++ b/cut/simple_example.sh
@@ -17,7 +17,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 # Call _rt_require_dracut_args() providing a script path that will be run on
 # VM boot. It exports variables used in the dracut invocation below.
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/simple_example.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/simple_example.sh" "$@"
 
 # The job of Rapido cut scripts is to generate a VM image. This is done using
 # Dracut with the following parameters...

--- a/cut/tcmu_file_iscsi.sh
+++ b/cut/tcmu_file_iscsi.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tcmu_file_iscsi.sh"
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tcmu_file_iscsi.sh" "$@"
 _rt_require_conf_dir TCMU_RUNNER_SRC
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df truncate \

--- a/cut/tcmu_rbd_loop.sh
+++ b/cut/tcmu_rbd_loop.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tcmu_rbd_loop.sh"
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tcmu_rbd_loop.sh" "$@"
 _rt_require_conf_dir TCMU_RUNNER_SRC CEPH_SRC
 _rt_require_ceph
 # NSS_InitContext() fails without the following...

--- a/cut/tgt_local.sh
+++ b/cut/tgt_local.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tgt_local.sh"
+_rt_require_dracut_args "${RAPIDO_DIR}/autorun/tgt_local.sh" "$@"
 _rt_require_conf_dir TGT_SRC
 
 "$DRACUT" \

--- a/cut/usb_rbd.sh
+++ b/cut/usb_rbd.sh
@@ -16,7 +16,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_ceph
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/usb_rbd.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/usb_rbd.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/zonefstests_nullblk.sh
+++ b/cut/zonefstests_nullblk.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_nullblk.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_nullblk.sh" "$@"
 _rt_require_conf_dir ZONEFSTOOLS_SRC
 
 "$DRACUT" \

--- a/cut/zonefstests_scsi.sh
+++ b/cut/zonefstests_scsi.sh
@@ -15,7 +15,7 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_scsi.sh"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/zonefstests_scsi.sh" "$@"
 _rt_require_conf_dir ZONEFSTOOLS_SRC
 
 "$DRACUT" \

--- a/rapido
+++ b/rapido
@@ -76,7 +76,7 @@ rapido_cut()
 	shift $(($OPTIND - 1))
 	local testname=$1
 
-	if [ -z "$testname" -o x"$testname" = "xhelp" ]; then
+	if [ $# -ne 1 -o -z "$testname" -o x"$testname" = "xhelp" ]; then
 		progname="$(basename $0)"
 		funcname="$(echo ${FUNCNAME[0]} | sed 's/^rapido_//;s/_/-/g')" 
 		cat << EOF

--- a/rapido
+++ b/rapido
@@ -45,10 +45,15 @@ rapido_cut()
 {
 	local boot_img="yes"
 	local option=""
-	while getopts "B" option; do
+	local post_autorun_files=()
+	while getopts "Bf:" option; do
 		case $option in
 		B)
 			unset boot_img
+			;;
+		f)
+			# existence checked via _rt_require_dracut_args()
+			post_autorun_files+=($(realpath "$OPTARG"))
 			;;
 		*)
 			echo "Invalid cut parameter"
@@ -64,9 +69,10 @@ rapido_cut()
 	if [ -z "$testname" -o x"$testname" = "xhelp" ]; then
 		progname="$(basename $0)"
 		funcname="$(echo ${FUNCNAME[0]} | sed 's/^rapido_//;s/_/-/g')" 
-		echo "Usage: ${progname} ${funcname} [-B] testname"
+		echo "Usage: ${progname} ${funcname} [-B] [-f file] testname"
 		echo ""
-		echo "-B:	cut testcase image only, don't boot it"
+		echo "-B:		cut testcase image only, don't boot it"
+		echo "-f <file>:	run script file within the VM upon boot"
 		echo "Where testname is one of the following:"
 		rapido_list
 		exit
@@ -85,7 +91,7 @@ rapido_cut()
 	fi
 
 	rm -f "${RAPIDO_DIR}/initrds/myinitrd"
-	./$cut_script
+	./$cut_script "${post_autorun_files[@]}"
 	local cut_status=$?
 	popd > /dev/null
 	[ $cut_status -ne 0 ] && exit $cut_status

--- a/rapido
+++ b/rapido
@@ -46,7 +46,9 @@ rapido_cut()
 	local boot_img="yes"
 	local option=""
 	local post_autorun_files=()
-	while getopts "Bf:" option; do
+	local cleanup="rm "
+	local t
+	while getopts "Bf:x:" option; do
 		case $option in
 		B)
 			unset boot_img
@@ -55,12 +57,20 @@ rapido_cut()
 			# existence checked via _rt_require_dracut_args()
 			post_autorun_files+=($(realpath "$OPTARG"))
 			;;
+		x)
+			t="$(mktemp --tmpdir rapido_post_autorun.XXXXXXXXXX)" \
+				|| exit 1
+			printf "%s" "$OPTARG" > "$t" || exit 1
+			post_autorun_files+=("$t")
+			cleanup="$cleanup \"$t\""
+			;;
 		*)
 			echo "Invalid cut parameter"
 			exit 1
 			;;
 		esac
 	done
+	[ -f "$t" ] && trap "$cleanup" 0 1 2 3 15
 
 	# shift away any processed params, so we're left with testname
 	shift $(($OPTIND - 1))
@@ -69,11 +79,14 @@ rapido_cut()
 	if [ -z "$testname" -o x"$testname" = "xhelp" ]; then
 		progname="$(basename $0)"
 		funcname="$(echo ${FUNCNAME[0]} | sed 's/^rapido_//;s/_/-/g')" 
-		echo "Usage: ${progname} ${funcname} [-B] [-f file] testname"
-		echo ""
-		echo "-B:		cut testcase image only, don't boot it"
-		echo "-f <file>:	run script file within the VM upon boot"
-		echo "Where testname is one of the following:"
+		cat << EOF
+Usage: ${progname} ${funcname} [-B] [-f file] [-x cmd] testname
+
+-B:		cut testcase image only, don't boot it
+-f <file>:	run script file within the VM upon boot
+-x <cmd>:	run command string within the VM upon boot
+Where testname is one of the following:
+EOF
 		rapido_list
 		exit
 

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -140,6 +140,7 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 ###########################
 
 ####### autorun/fstests_*.sh #######
+# XXX DEPRECATED: use the rapido cut '-x' or '-f' parameters instead
 # If defined, run the following command from within the fstests source directory
 # following VM boot-up.
 # e.g. FSTESTS_AUTORUN_CMD="./check -g auto && shutdown"
@@ -184,6 +185,7 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 ##################################
 
 ####### autorun/blktests_*.sh #######
+# XXX DEPRECATED: use the rapido cut '-x' or '-f' parameters instead
 # If defined, run the following command from within the blktests source directory
 # following VM boot-up.
 # e.g. BLKTESTS_AUTORUN_CMD="./check && shutdown"
@@ -198,6 +200,7 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 ##################################
 
 ####### autorun/zonefstests_*.sh #######
+# XXX DEPRECATED: use the rapido cut '-x' or '-f' parameters instead
 # If defined, run the following command from within the zonefstests source directory
 # following VM boot-up.
 # e.g. ZONEFSTESTS_AUTORUN_CMD="./zonefs-tests.sh /dev/nullb0 && shutdown"
@@ -257,6 +260,8 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 # LTP_DIR should correspond to the ltp directory tree after make install.
 # e.g. LTP_DIR="/opt/ltp"
 #LTP_DIR=""
+#
+# XXX DEPRECATED: use the rapido cut '-x' or '-f' parameters instead
 # LTP_AUTORUN_CMD can be set to automatically run one or more testcases from
 # within the ltp directory.
 # e.g. LTP_AUTORUN_CMD="./runltp"

--- a/runtime.vars
+++ b/runtime.vars
@@ -22,8 +22,12 @@ _warn() {
 }
 
 # process user defined configuration
-. ${RAPIDO_DIR}/rapido.conf \
-	|| _fail "rapido.conf missing - see rapido.conf.example"
+RAPIDO_CONF="${RAPIDO_CONF:-${RAPIDO_DIR}/rapido.conf}"
+. $RAPIDO_CONF \
+	|| _fail "$RAPIDO_CONF processing failed - see rapido.conf.example"
+
+# initramfs output path
+DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
 
 _rt_ceph_src_globals_set() {
 	[ -d "$CEPH_SRC" ] || _fail "$CEPH_SRC is not a directory"
@@ -198,12 +202,11 @@ _rt_require_dracut_args() {
 	done
 
 	# specify core init scripts responsible for starting autorun
-	local conf_src="$RAPIDO_DIR/rapido.conf"
 	local env_src="$RAPIDO_DIR/vm_autorun.env"
 	local emerg_src="$RAPIDO_DIR/autorun/00-rapido-init.sh"
 	local emerg_dst="/lib/dracut/hooks/emergency/00-rapido-init.sh"
 	DRACUT_RAPIDO_INCLUDES="$DRACUT_RAPIDO_INCLUDES
-				--include $conf_src /rapido.conf \
+				--include $RAPIDO_CONF /rapido.conf \
 				--include $env_src /.profile \
 				--include $emerg_src $emerg_dst"
 
@@ -328,9 +331,6 @@ _rt_require_samba_ctdb() {
 	CTDB_EVENTS_DIR="$(ls -d ${SAMBA_SRC}/ctdb/config/events*)"
 	[ -d "$CTDB_EVENTS_DIR" ] || _fail "$CTDB_EVENTS_DIR missing"
 }
-
-# initramfs output path
-DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
 
 _rt_xattr_qemu_args_set() {
 	local img="$1"

--- a/selftest/selftest.sh
+++ b/selftest/selftest.sh
@@ -75,9 +75,6 @@ _run_tests() {
 	echo "All $tnum tests passed"
 }
 
-[ -f "${RAPIDO_DIR}/rapido.conf" ] \
-	&& _fail "refusing to run with existing rapido.conf"
-
 FILTER="$1"
 if [ -n "$FILTER" ]; then
 	[ "$FILTER" == "${FILTER#*/}" ] || _fail "filter can't include /"
@@ -91,10 +88,7 @@ fi
 [ -z "$QEMU_EXTRA_KERNEL_PARAMS" ] || _fail "QEMU_EXTRA_KERNEL_PARAMS is set"
 
 _generate_conf "${TD}/rapido.conf"
-
-ln -s ${TD}/rapido.conf "${RAPIDO_DIR}/rapido.conf" \
-	|| _fail "failed to link config"
-CLEANUP="${CLEANUP}; rm -f ${RAPIDO_DIR}/rapido.conf"
+export RAPIDO_CONF="${TD}/rapido.conf"
 
 pushd "${RAPIDO_DIR}"
 

--- a/selftest/selftest.sh
+++ b/selftest/selftest.sh
@@ -14,8 +14,8 @@
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
-TD="$(mktemp -d rapido-selftest.XXXXXXX)"
-CLEANUP="rm -f ${TD}/*; rmdir $TD"
+export RAPIDO_SELFTEST_TMPDIR="$(mktemp -d rapido-selftest.XXXXXXX)"
+CLEANUP="rm -f ${RAPIDO_SELFTEST_TMPDIR}/*; rmdir $RAPIDO_SELFTEST_TMPDIR"
 # cleanup tmp dir when done
 trap "$CLEANUP" 0 1 2 3 15
 
@@ -57,8 +57,7 @@ _generate_conf() {
 }
 
 _run_tests() {
-	local td="$1"
-	local filter="$2"
+	local filter="$1"
 	local tnum=0
 	local t
 
@@ -87,11 +86,12 @@ fi
 [ -z "$QEMU_EXTRA_ARGS" ] || _fail "QEMU_EXTRA_ARGS is set"
 [ -z "$QEMU_EXTRA_KERNEL_PARAMS" ] || _fail "QEMU_EXTRA_KERNEL_PARAMS is set"
 
-_generate_conf "${TD}/rapido.conf"
-export RAPIDO_CONF="${TD}/rapido.conf"
+_generate_conf "${RAPIDO_SELFTEST_TMPDIR}/rapido.conf"
+export RAPIDO_CONF="${RAPIDO_SELFTEST_TMPDIR}/rapido.conf"
+export RAPIDO_SELFTEST_TMPDIR="$RAPIDO_SELFTEST_TMPDIR"
 
 pushd "${RAPIDO_DIR}"
 
-_run_tests "$TD" "$FILTER"
+_run_tests "$FILTER"
 
 popd

--- a/selftest/test/004
+++ b/selftest/test/004
@@ -1,0 +1,78 @@
+#!/usr/bin/expect -f
+#
+# Copyright (C) SUSE LLC 2020, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+# exercise -f and -x post-autorun parameters
+
+log_user 0
+log_file -a $::env(RAPIDO_SELFTEST_TMPDIR)/004.log
+
+set ::cleanup_pids {}
+exit -onexit {
+	foreach pid $::cleanup_pids {
+		send_log "killing $pid"
+		exec kill -9 $pid
+	}
+}
+
+set timeout 60
+set ar_str_sh "echo post autorun script passed as string"
+set ar_file_sh $::env(RAPIDO_SELFTEST_TMPDIR)/004-postautorun.sh
+exec echo "echo post autorun script passed as file" > $ar_file_sh
+spawn ./rapido cut -x "$ar_str_sh" -f $ar_file_sh simple-example
+lappend ::cleanup_pids [exp_pid -i $spawn_id]
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"post autorun script passed as string"
+}
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"post autorun script passed as file"
+}
+
+send "shutdown\r"
+expect {
+	timeout {exit 1}
+	eof {wait}
+}
+set ::cleanup_pids {}
+
+# same again, but change order of execution
+spawn ./rapido cut -f $ar_file_sh -x "$ar_str_sh" -f $ar_file_sh simple-example
+lappend ::cleanup_pids [exp_pid -i $spawn_id]
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"post autorun script passed as file"
+}
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"post autorun script passed as string"
+}
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"post autorun script passed as file"
+}
+send "shutdown\r"
+expect {
+	timeout {exit 1}
+	eof {wait}
+}
+set ::cleanup_pids {}

--- a/tools/bash_completion
+++ b/tools/bash_completion
@@ -43,6 +43,12 @@ __rapido()
 
 	rcmd="${COMP_WORDS[1]}"	# rapido command should be at offset 1
 	if [[ ${rcmd} =~ "cut" ]]; then
+		if [[ " ${COMP_WORDS[COMP_CWORD-1]} " =~ " -f " ]]; then
+			# -f takes a filename parameter, so complete that only
+			COMPREPLY=( $(compgen -o filenames -A file -- ${cur}) )
+			return 0
+		fi
+
 		seen_boot=0
 		max_off=2
 		for (( i=2; i<=$COMP_CWORD; i++ )); do
@@ -52,12 +58,16 @@ __rapido()
 				seen_boot=1
 				(( max_off++ ))
 				;;
+			"-f")
+				(( max_off+=2 ))
+				(( i++ ))	# skip any file name
+				;;
 			esac
 		done
 
 		(( $COMP_CWORD > $max_off )) && return 0
 
-		(( seen_boot == 0 )) && comps="-B"
+		(( seen_boot == 0 )) && comps="-f -B" || comps="-f"
 		pushd "${cut_dir}" &> /dev/null || return 0
 		comps="${comps} $(ls *.sh | sed 's/\.sh$//;s/_/-/g')"
 		popd &> /dev/null

--- a/tools/bash_completion
+++ b/tools/bash_completion
@@ -49,6 +49,9 @@ __rapido()
 			return 0
 		fi
 
+		# don't attempt to complete -x <cmd> string
+		[[ " ${COMP_WORDS[COMP_CWORD-1]} " =~ " -x " ]] && return 0
+
 		seen_boot=0
 		max_off=2
 		for (( i=2; i<=$COMP_CWORD; i++ )); do
@@ -62,12 +65,16 @@ __rapido()
 				(( max_off+=2 ))
 				(( i++ ))	# skip any file name
 				;;
+			"-x")
+				(( max_off+=2 ))
+				(( i++ ))	# skip script
+				;;
 			esac
 		done
 
 		(( $COMP_CWORD > $max_off )) && return 0
-
-		(( seen_boot == 0 )) && comps="-f -B" || comps="-f"
+		comps="-f -x"
+		(( seen_boot == 0 )) && comps="$comps -B"
 		pushd "${cut_dir}" &> /dev/null || return 0
 		comps="${comps} $(ls *.sh | sed 's/\.sh$//;s/_/-/g')"
 		popd &> /dev/null

--- a/tools/bash_completion
+++ b/tools/bash_completion
@@ -22,7 +22,7 @@
 
 __rapido()
 {
-	local bin cut_dir cur prev comps
+	local bin cut_dir cur comps rcmd max_off seen_boot
 	bin="$1"
 
 	# we only want to complete the rapido script, not dirs, etc.
@@ -34,29 +34,36 @@ __rapido()
 
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
-	prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-	if [[ ${prev} =~ "-B" ]]; then
-		# -B subparameter is provided (for cut?)
-		prev="${COMP_WORDS[COMP_CWORD-2]}"
-	else
-		# cut should include "-B" completion
-		comps="-B"
-	fi
-
-	if [[ ${prev} =~ "cut" ]]; then
-		pushd "${cut_dir}" &> /dev/null || return 0
-		comps="${comps} $(ls *.sh | sed 's/\.sh$//;s/_/-/g')"
-		popd &> /dev/null
-		COMPREPLY=( $(compgen -W "${comps}" -- ${cur}) )
-		return 0
-	fi
-
-	if [[ ${cur} == * ]]; then
+	if (( $COMP_CWORD <= 1 )); then
 		comps="boot cut help list setup-network teardown-network"
 		COMPREPLY=( $(compgen -W "${comps}" -- ${cur}) )
 		return 0
 	fi
+
+	rcmd="${COMP_WORDS[1]}"	# rapido command should be at offset 1
+	if [[ ${rcmd} =~ "cut" ]]; then
+		seen_boot=0
+		max_off=2
+		for (( i=2; i<=$COMP_CWORD; i++ )); do
+			case "${COMP_WORDS[i]}" in
+			"-B")
+				(( seen_boot == 0 )) || return 0
+				seen_boot=1
+				(( max_off++ ))
+				;;
+			esac
+		done
+
+		(( $COMP_CWORD > $max_off )) && return 0
+
+		(( seen_boot == 0 )) && comps="-B"
+		pushd "${cut_dir}" &> /dev/null || return 0
+		comps="${comps} $(ls *.sh | sed 's/\.sh$//;s/_/-/g')"
+		popd &> /dev/null
+		COMPREPLY=( $(compgen -W "${comps}" -- ${cur}) )
+	fi
+	return 0
 }
 
 complete -F __rapido rapido


### PR DESCRIPTION
We currently provide rapido.conf `FSTESTS_AUTORUN_CMD`, `BLKTESTS_AUTORUN_CMD`, etc. parameters for running arbitrary commands after the autorun script has setup the test environment.
This patchset adds new rapido cut -f <script> and -x <command> parameters to run an arbitrary script file or command after autorun has completed. Multiple <script> or <command> parameters can be specified, and they will be executed in the order of appearance. E.g.
```
./rapido cut -x "echo run me..." -x "echo after autorun" simple-example
...
Rapido: starting /rapido_autorun/00-simple_example.sh
...
Rapido scratch VM running. Have a lot of fun...
Rapido: starting /rapido_autorun/01-rapido_post_autorun.6q9lTJL9EU
run me...
Rapido: starting /rapido_autorun/02-rapido_post_autorun.k2pWEUYvwy
after autorun
rapido1:/#
```
IMO this offers a more flexible approach than `FSTESTS_AUTORUN_CMD`, etc. making integration with kernel CI utilities much more straightforward.

@morbidrsa / @luis-henrix : interested to hear your thoughts on this.