### PR TITLE
unionmount_testsuite: add cut and autorun scripts

### DIFF
--- a/autorun/unionmount_testsuite.sh
+++ b/autorun/unionmount_testsuite.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+num_devs="2"
+modprobe zram num_devices="$num_devs" || _fatal "failed to load zram module"
+
+_vm_ar_dyn_debug_enable
+
+mkdir -p /base /lower /upper /mnt
+
+for lowerfs in "xfs" "btrfs"; do
+	for upperfs in "xfs" "btrfs"; do
+		echo "running tests with lowerfs=${lowerfs} upperfs=${upperfs}"
+		for ((i=0; i < $num_devs; i++)); do
+			echo "1" > /sys/block/zram${i}/reset || _fatal
+			echo "1G" > /sys/block/zram${i}/disksize || _fatal
+		done
+
+		mkfs.${lowerfs} "/dev/zram0" || _fatal
+		echo /dev/zram0 /lower $lowerfs noauto > /etc/fstab
+		mkfs.${upperfs} "/dev/zram1" || _fatal
+		echo /dev/zram1 /upper $upperfs noauto >> /etc/fstab
+
+		pushd "$UNIONMOUNT_TESTSUITE_SRC"
+		./run --ov || _fatal "test failed"
+		popd
+		cat /proc/mounts
+		umount /base /lower /upper /mnt
+	done
+done
+echo "all tests completed"
+shutdown

--- a/cut/unionmount_testsuite.sh
+++ b/cut/unionmount_testsuite.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/unionmount_testsuite.sh" "$@"
+_rt_require_conf_dir UNIONMOUNT_TESTSUITE_SRC
+
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs.xfs mkfs.btrfs python3" \
+	--include "$UNIONMOUNT_TESTSUITE_SRC" "$UNIONMOUNT_TESTSUITE_SRC" \
+	--include "/usr/lib64/python3.6/" "/usr/lib64/python3.6/" \
+	$DRACUT_RAPIDO_INCLUDES \
+	--add-drivers "zram lzo lzo-rle btrfs raid6_pq overlay" \
+	--modules "bash base" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+_rt_xattr_vm_networkless_set "$DRACUT_OUT"
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "1024M"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -213,6 +213,13 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 # e.g. ZONEFSTOOLS_SRC="/home/me/zonefs-tools"
 ##################################
 
+#### unionmount_testsuite.sh ####
+## UNIONMOUNT_TESTSUITE_SRC should correspond to a checkout of the test suite
+## available at https://github.com/amir73il/unionmount-testsuite
+## e.g. UNIONMOUNT_TESTSUITE_SRC="/home/me/unionmount-testsuite"
+#UNIONMOUNT_TESTSUITE_SRC=""
+###################################
+
 ######## cut/usb_rbd.sh #########
 # RBD_USB_SRC should correspond to a checkout and build of
 # https://github.com/ddiss/rbd-usb.


### PR DESCRIPTION
This runs the upstream overlayfs test suite, as documented at
https://github.com/amir73il/overlayfs/wiki/Overlayfs-testing .

Signed-off-by: David Disseldorp <ddiss@suse.de>