### PR TITLE
WIP: rapido: add fstests-btrfs-zoned cut script

### DIFF
--- a/autorun/fstests_btrfs_zoned.sh
+++ b/autorun/fstests_btrfs_zoned.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (C) Western Digital Corporation 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+create_zoned_null_blk()
+{
+	dev="/sys/kernel/config/nullb/$1"
+	mkdir "$dev" || _fatal "cannot create nullb0 device"
+
+	size=12800 # MB
+	echo 2 > "$dev"/submit_queues
+	echo "${size}" > "${dev}"/size
+	echo 1 > "${dev}"/zoned
+	echo 4 > "${dev}"/zone_nr_conv
+	echo 1 > "${dev}"/memory_backed
+	echo 1 > "$dev"/power
+}
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+[ -n "$BTRFS_PROGS_SRC" ] && export PATH="${PATH}:${BTRFS_PROGS_SRC}"
+
+_vm_ar_hosts_create
+
+filesystem="btrfs"
+
+modprobe null_blk nr_devices="0" || _fatal "failed to load null_blk module"
+
+_vm_ar_dyn_debug_enable
+_vm_ar_configfs_mount
+
+# create the btrfs null_blk devices.
+for d in nullb0 nullb1; do
+	create_zoned_null_blk $d
+done
+
+
+mkdir -p /mnt/test
+mkdir -p /mnt/scratch
+
+mkfs.${filesystem} /dev/nullb0 || _fatal "mkfs failed"
+mount -t $filesystem /dev/nullb0 /mnt/test || _fatal
+# xfstests can handle scratch mkfs+mount
+
+[ -n "${FSTESTS_SRC}" ] || _fatal "FSTESTS_SRC unset"
+[ -d "${FSTESTS_SRC}" ] || _fatal "$FSTESTS_SRC missing"
+
+cfg="${FSTESTS_SRC}/configs/$(hostname -s).config"
+cat > $cfg << EOF
+FSTYP=btrfs
+MODULAR=0
+TEST_DIR=/mnt/test
+TEST_DEV=/dev/nullb0
+SCRATCH_MNT=/mnt/scratch
+SCRATCH_DEV="/dev/nullb1"
+USE_KMEMLEAK=yes
+EOF
+
+set +x
+
+echo "$filesystem filesystem ready for FSQA"
+
+if [ -n "$FSTESTS_AUTORUN_CMD" ]; then
+	cd ${FSTESTS_SRC} || _fatal
+	eval "$FSTESTS_AUTORUN_CMD"
+fi

--- a/cut/fstests_btrfs_zoned.sh
+++ b/cut/fstests_btrfs_zoned.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (C) Western Digital Corporation 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs_zoned.sh" "$@"
+_rt_require_fstests
+_rt_require_btrfs_progs
+
+# wipefs mount
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs  free \
+		   which perl awk bc touch cut chmod true false unlink \
+		   mktemp getfattr setfattr chacl attr killall hexdump sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   basename tee egrep yes mkswap timeout \
+		   fstrim fio logger dmsetup chattr lsattr cmp stat \
+		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		   repquota setquota quotacheck quotaon pvremove vgremove \
+		   xfs_mkfile xfs_db xfs_io filefrag losetup \
+		   chgrp du fgrep pgrep tar rev kill duperemove blkzone \
+		   swapon swapoff xfs_freeze fsck blktrace blkparse \
+		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${FSTESTS_SRC}/src/log-writes/* \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*
+		   $BTRFS_PROGS_BINS" \
+	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	$DRACUT_RAPIDO_INCLUDES \
+	--include "$RAPIDO_DIR/wipefs" "/usr/sbin/wipefs" \
+	--include "$RAPIDO_DIR/mount" "/usr/sbin/mount" \
+	--add-drivers "lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
+		       loop scsi_debug dm-log-writes xxhash_generic null_blk" \
+	--modules "bash base" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+_rt_xattr_vm_networkless_set "$DRACUT_OUT"
+# need enough memory for two 12G null_blk devices
+_rt_xattr_vm_resources_set "$DRACUT_OUT" "2" "16384M"


### PR DESCRIPTION
Work in Progress!!!!

Add support for running fastest with btrfs on zoned null_blk devices.

Upstream btrfs has not yet merged zoned support (only staged in a separate branch) and user-space utilities are not update upstream either. But we have been using this cut script for about one year assisting our development of the patches.