### PR TITLE
cut: drop unnecessary "bash" Dracut module

### DIFF
--- a/cut/blktests_rbd.sh
+++ b/cut/blktests_rbd.sh
@@ -38,6 +38,6 @@ _rt_require_blktests
 	--include "$BLKTESTS_SRC" "/blktests" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "scsi_debug null_blk loop" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/blktests_zram.sh
+++ b/cut/blktests_zram.sh
@@ -27,7 +27,7 @@ _rt_require_blktests
 	--include "$BLKTESTS_SRC" "/blktests" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle scsi_debug null_blk loop nvme nvme-loop" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/cephfs.sh
+++ b/cut/cephfs.sh
@@ -29,6 +29,6 @@ _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/cephfs.sh" "$@"
 		   id sort uniq date expr tac diff head dirname seq ip ping" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "ceph libceph" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -36,6 +36,6 @@ _rt_require_lib "libsoftokn3.so \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "fuse" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/cifs.sh
+++ b/cut/cifs.sh
@@ -24,6 +24,6 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/cifs.sh" "$@"
 		   dirname seq basename fstrim chattr lsattr stat" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm gcm ctr" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/ctdb_cephfs.sh
+++ b/cut/ctdb_cephfs.sh
@@ -64,7 +64,7 @@ _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/dropbear.sh
+++ b/cut/dropbear.sh
@@ -22,6 +22,6 @@ _rt_require_lib "libkeyutils.so.1"
 		   strace mkfs.xfs dropbear chmod ip ping \
 		   $LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/fcoe_local.sh
+++ b/cut/fcoe_local.sh
@@ -24,7 +24,7 @@ _rt_require_lib "libkeyutils.so.1"
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod tcm_fc target_core_iblock \
 			target_core_file libfc fcoe scsi_debug" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -40,7 +40,7 @@ _rt_require_btrfs_progs
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
 		       loop scsi_debug dm-log-writes xxhash_generic" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -42,7 +42,7 @@ _rt_require_fstests
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -36,7 +36,7 @@ _rt_require_fstests
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm ctr" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -38,7 +38,7 @@ _rt_require_fstests
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey xfs" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/lio_local.sh
+++ b/cut/lio_local.sh
@@ -23,7 +23,7 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_local.sh" "$@"
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_iblock \
 		       target_core_file dm-delay loop" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/lio_pscsi_loop.sh
+++ b/cut/lio_pscsi_loop.sh
@@ -27,7 +27,7 @@ _rt_require_dracut_args "${RAPIDO_DIR}/autorun/lio_pscsi_loop.sh" "$@"
 		   env lsscsi awk" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi target_core_pscsi tcm_loop" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/lio_rbd.sh
+++ b/cut/lio_rbd.sh
@@ -33,6 +33,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/lrbd.sh
+++ b/cut/lrbd.sh
@@ -50,7 +50,7 @@ rados_cython="${CEPH_SRC}"/build/lib/cython_modules/lib.3/rados.cpython-34m.so
 	--include "$CONFIGSHELL_SRC" "/configshell/" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "iscsi_target_mod target_core_mod target_core_rbd" \
-	--modules "bash base systemd systemd-initrd dracut-systemd" \
+	--modules "base systemd systemd-initrd dracut-systemd" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -32,7 +32,7 @@ _rt_require_conf_dir LTP_DIR
 	--include "$LTP_DIR" "$LTP_DIR"  \
 	--include "${KERNEL_SRC}/.config" /.config \
 	--add-drivers "loop" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/mpath_local.sh
+++ b/cut/mpath_local.sh
@@ -33,7 +33,7 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/mpath_local.sh" "$@"
 		   timeout id chown chmod env killall getopt basename" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "virtio_scsi virtio_pci sd_mod" \
-	--modules "bash base systemd systemd-initrd dracut-systemd multipath" \
+	--modules "base systemd systemd-initrd dracut-systemd multipath" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT \
 	|| _fail "dracut failed"

--- a/cut/nvme_local.sh
+++ b/cut/nvme_local.sh
@@ -23,7 +23,7 @@ _rt_require_lib "libkeyutils.so.1"
 		   $LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet zram lzo lzo-rle" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/nvme_rbd.sh
+++ b/cut/nvme_rbd.sh
@@ -33,6 +33,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/nvme_rdma.sh
+++ b/cut/nvme_rdma.sh
@@ -25,6 +25,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \
 		       rdma_rxe zram lzo lzo-rle ib_core ib_uverbs rdma_ucm \
 		       crc32_generic" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/nvme_tcp_initiator.sh
+++ b/cut/nvme_tcp_initiator.sh
@@ -22,6 +22,6 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_tcp_initiator.sh" "$@"
 	$DRACUT_RAPIDO_INCLUDES \
 	--include "$vm_ceph_conf" "/vm_ceph.env" \
 	--add-drivers "nvme-core nvme-fabrics nvme-tcp" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/nvme_tcp_rbd.sh
+++ b/cut/nvme_tcp_rbd.sh
@@ -34,6 +34,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvmet-tcp nvmet" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/openiscsi.sh
+++ b/cut/openiscsi.sh
@@ -24,7 +24,7 @@ _rt_require_conf_dir OPENISCSI_SRC
 		   ${OPENISCSI_SRC}/libopeniscsiusr/libopeniscsiusr.so \
 		   ${OPENISCSI_SRC}/usr/iscsiadm" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--modules "bash base" \
+	--modules "base" \
 	--drivers "iscsi_tcp" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/qemu_rbd.sh
+++ b/cut/qemu_rbd.sh
@@ -23,7 +23,7 @@ _rt_require_lib "libkeyutils.so.1"
 		   strace mkfs.xfs lsscsi \
 		   $LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/rbd.sh
+++ b/cut/rbd.sh
@@ -32,6 +32,6 @@ _rt_require_lib "libkeyutils.so.1"
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \
 	--include "$RBD_UDEV_RULES" "/usr/lib/udev/rules.d/50-rbd.rules" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/rbd_nbd.sh
+++ b/cut/rbd_nbd.sh
@@ -37,6 +37,6 @@ rbd_nbd_bin="${CEPH_SRC}/build/bin/rbd-nbd"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nbd" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -42,7 +42,7 @@ _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -34,7 +34,7 @@ _rt_require_conf_dir SAMBA_SRC
 		   ${SAMBA_SRC}/bin/smbd" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "ceph libceph" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -29,7 +29,7 @@ _rt_require_conf_dir SAMBA_SRC
 		   ${SAMBA_SRC}/bin/smbd" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle xfs btrfs" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/simple_example.sh
+++ b/cut/simple_example.sh
@@ -40,7 +40,7 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/simple_example.sh" "$@"
 	--install "resize ps rmdir dd mkfs.xfs" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/tcmu_file_iscsi.sh
+++ b/cut/tcmu_file_iscsi.sh
@@ -24,7 +24,7 @@ _rt_require_conf_dir TCMU_RUNNER_SRC
 		   ${TCMU_RUNNER_SRC}/handler_file.so" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod target_core_user iscsi_target_mod" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/tcmu_rbd_loop.sh
+++ b/cut/tcmu_rbd_loop.sh
@@ -33,6 +33,6 @@ _rt_require_lib "libsoftokn3.so libfreeblpriv3.so"
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod target_core_user tcm_loop" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/tgt_local.sh
+++ b/cut/tgt_local.sh
@@ -24,7 +24,7 @@ _rt_require_conf_dir TGT_SRC
 		   ${TGT_SRC}/usr/tgtadm" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/unionmount_testsuite.sh
+++ b/cut/unionmount_testsuite.sh
@@ -24,7 +24,7 @@ _rt_require_conf_dir UNIONMOUNT_TESTSUITE_SRC
 	--include "/usr/lib64/python3.6/" "/usr/lib64/python3.6/" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "zram lzo lzo-rle btrfs raid6_pq overlay" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/usb_rbd.sh
+++ b/cut/usb_rbd.sh
@@ -37,6 +37,6 @@ _rt_require_lib "libkeyutils.so.1"
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "target_core_mod target_core_iblock usb_f_tcm \
 		       usb_f_mass_storage zram lzo lzo-rle dm-crypt" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT

--- a/cut/zonefstests_nullblk.sh
+++ b/cut/zonefstests_nullblk.sh
@@ -24,7 +24,7 @@ _rt_require_conf_dir ZONEFSTOOLS_SRC
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "null_blk zonefs" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 

--- a/cut/zonefstests_scsi.sh
+++ b/cut/zonefstests_scsi.sh
@@ -24,7 +24,7 @@ _rt_require_conf_dir ZONEFSTOOLS_SRC
 	--include "$ZONEFSTOOLS_SRC/tests/" "/zonefs-tests" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "scsi_debug zonefs" \
-	--modules "bash base" \
+	--modules "base" \
 	$DRACUT_EXTRA_ARGS \
 	$DRACUT_OUT || _fail "dracut failed"
 


### PR DESCRIPTION
This change is a straight s/bash base/base/ substitution in cut/*.
The Dracut "base" module already installs the bash binary, so explicitly
adding it via the extra "bash" module is unnecessary.

Signed-off-by: David Disseldorp <ddiss@suse.de>