### PR TITLE
uring_btrfs: add liburing test suite runner

### DIFF
--- a/autorun/uring_btrfs.sh
+++ b/autorun/uring_btrfs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+modprobe zram num_devices="1" || _fatal "failed to load zram module"
+
+_vm_ar_dyn_debug_enable
+
+echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"
+
+mkfs.btrfs /dev/zram0 || _fatal "mkfs failed"
+
+mkdir -p /mnt
+mount -t btrfs /dev/zram0 /mnt || _fatal
+chmod 777 /mnt || _fatal
+
+set +x
+
+# liburing tests run from CWD so we unfortunately have to move them over
+mv ${LIBURING_SRC}/test /mnt || _fatal
+cd /mnt/test || _fatal
+
+cat <<EOF
+To run a test:
+  ./runtests.sh <test_name>
+
+E.g. to run all tests on boot:
+  ./rapido cut -x './runtests.sh \$(cat /uring_tests.manifest)' uring-btrfs
+EOF

--- a/cut/uring_btrfs.sh
+++ b/cut/uring_btrfs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/uring_btrfs.sh" "$@"
+_rt_require_conf_dir LIBURING_SRC
+
+test_manifest="$(mktemp --tmpdir iouring_tests.XXXXX)"
+# remove tmp file once we're done
+trap "rm $test_manifest" 0 1 2 3 15
+
+pushd ${LIBURING_SRC}/test || _fail
+find . -type f -executable ! -name '*.sh' -fprintf "$test_manifest" '%P\n'
+popd
+test_bins=$(sed "s#^#${LIBURING_SRC}/test/#" "$test_manifest")
+
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs mkfs.btrfs tee timeout \
+		   stat which touch cut chmod true false \
+		   id sort uniq date expr tac diff head dirname seq \
+		   ${LIBURING_SRC}/test/runtests.sh \
+		   $test_bins" \
+	$DRACUT_RAPIDO_INCLUDES \
+	--include "$test_manifest" "/uring_tests.manifest" \
+	--add-drivers "zram lzo lzo-rle btrfs" \
+	--modules "base" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"
+
+_rt_xattr_vm_networkless_set "$DRACUT_OUT"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -220,6 +220,13 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #UNIONMOUNT_TESTSUITE_SRC=""
 ###################################
 
+######### uring_btrfs.sh #########
+# LIBURING_SRC should correspond to a checkout and build of the liburing source
+# available at https://github.com/axboe/liburing
+# e.g. LIBURING_SRC="/home/me/liburing"
+#LIBURING_SRC=""
+###################################
+
 ######## cut/usb_rbd.sh #########
 # RBD_USB_SRC should correspond to a checkout and build of
 # https://github.com/ddiss/rbd-usb.


### PR DESCRIPTION
Install test files from ${LIBURING_SRC}/test. Boot doesn't start any
tests, as this can be done with cut -x, E.g.
  rapido cut -x './runtests.sh $(cat /uring_tests.manifest)' uring-btrfs

Signed-off-by: David Disseldorp <ddiss@suse.de>