### PR TITLE
cifs.ko kerberos authentication testing

### DIFF
--- a/autorun/cifs.sh
+++ b/autorun/cifs.sh
@@ -14,7 +14,10 @@
 
 _vm_ar_env_check || exit 1
 
+modprobe cifs
 _vm_ar_dyn_debug_enable
+
+[ -n "$CIFS_UTILS_SRC" ] && ln -s "${CIFS_UTILS_SRC}/mount.cifs" /sbin/
 
 creds_path="/tmp/cifs_creds"
 [ -n "$CIFS_DOMAIN" ] && echo "domain=${CIFS_DOMAIN}" >> $creds_path

--- a/autorun/cifs_krb.sh
+++ b/autorun/cifs_krb.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+_vm_ar_env_check || exit 1
+
+modprobe cifs
+_vm_ar_dyn_debug_enable
+
+if [ -n "$CIFS_UTILS_SRC" ]; then
+	ln -s "${CIFS_UTILS_SRC}/mount.cifs" /sbin/
+	ln -s "${CIFS_UTILS_SRC}/cifs.upcall" /usr/sbin/
+fi
+
+set -x
+
+cat >/etc/request-key.conf <<EOF
+create cifs.spnego  * * /usr/sbin/cifs.upcall %k
+EOF
+
+cat >/etc/krb5.conf <<EOF
+[libdefaults]
+dns_lookup_realm = true
+dns_lookup_kdc = true
+forwardable = true
+default_realm = $CIFS_DOMAIN
+
+[logging]
+	kdc = FILE:/var/log/krb5/krb5kdc.log
+	admin_server = FILE:/var/log/krb5/kadmind.log
+	default = FILE:/var/log/krb5/def.log
+EOF
+
+# XXX rely on DNS forwarding of CIFS_DOMAIN requests via BR_ADDR
+# E.g. dnsmasq --server=/${CIFS_DOMAIN}/${CIFS_SERVER}
+cat >/etc/resolv.conf <<EOF
+search ${CIFS_DOMAIN,,}
+nameserver ${BR_ADDR%/*}
+EOF
+
+mkdir -p /run/user/0 /var/log/krb5/ /mnt/cifs
+set +x
+echo "$CIFS_PW" | kinit "${CIFS_USER}"@"${CIFS_DOMAIN}" || _fatal
+klist || _fatal
+mount_args="-osec=krb5i,user=${CIFS_USER}"
+[ -n "$CIFS_MOUNT_OPTS" ] && mount_args="${mount_args},${CIFS_MOUNT_OPTS}"
+set -x
+
+mount -t cifs //"${CIFS_SERVER}"/"${CIFS_SHARE}" /mnt/cifs "$mount_args" \
+	|| _fatal
+cd /mnt/cifs || _fatal
+set +x

--- a/autorun/fstests_cifs.sh
+++ b/autorun/fstests_cifs.sh
@@ -16,8 +16,11 @@ _vm_ar_env_check || exit 1
 
 set -x
 
+modprobe cifs
 _vm_ar_hosts_create
 _vm_ar_dyn_debug_enable
+
+[ -n "$CIFS_UTILS_SRC" ] && ln -s "${CIFS_UTILS_SRC}/mount.cifs" /sbin/
 
 set +x
 creds_path="/tmp/cifs_creds"

--- a/cut/cifs.sh
+++ b/cut/cifs.sh
@@ -16,12 +16,14 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/cifs.sh" "$@"
+_rt_require_cifs_utils
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
-		   mount.cifs ip ping getfacl setfacl truncate du \
+		   ip ping getfacl setfacl truncate du \
 		   which touch cut chmod true false unlink \
 		   getfattr setfattr chacl attr killall sync \
-		   dirname seq basename fstrim chattr lsattr stat" \
+		   dirname seq basename fstrim chattr lsattr stat \
+		   $CIFS_UTILS_BINS" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm gcm ctr" \
 	--modules "base" \

--- a/cut/cifs_krb.sh
+++ b/cut/cifs_krb.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) version 3.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/cifs_krb.sh" "$@"
+_rt_require_lib "libnss_dns.so"
+_rt_require_cifs_utils
+_rt_require_conf_setting CIFS_DOMAIN CIFS_USER CIFS_PW CIFS_SHARE
+
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
+		   ip ping truncate du which touch chmod \
+		   killall sync dirname seq basename stat \
+		   request-key kinit klist \
+		   $LIBS_INSTALL_LIST \
+		   $CIFS_UTILS_BINS" \
+	$DRACUT_RAPIDO_INCLUDES \
+	--add-drivers "cifs ccm gcm ctr" \
+	--modules "base" \
+	$DRACUT_EXTRA_ARGS \
+	$DRACUT_OUT || _fail "dracut failed"

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -16,7 +16,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs.sh" "$@"
-_rt_require_fstests
+_rt_require_conf_dir FSTESTS_SRC
 _rt_require_btrfs_progs
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/fstests_btrfs_zoned.sh
+++ b/cut/fstests_btrfs_zoned.sh
@@ -16,7 +16,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs_zoned.sh" "$@"
-_rt_require_fstests
+_rt_require_conf_dir FSTESTS_SRC
 _rt_require_btrfs_progs
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \

--- a/cut/fstests_cephfs.sh
+++ b/cut/fstests_cephfs.sh
@@ -23,7 +23,7 @@ _rt_require_dracut_args "$vm_ceph_conf" \
 			"$RAPIDO_DIR/autorun/fstests_cephfs.sh" "$@"
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_fstests
+_rt_require_conf_dir FSTESTS_SRC
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs free \

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -17,9 +17,10 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cifs.sh" "$@"
 _rt_require_conf_dir FSTESTS_SRC
+_rt_require_cifs_utils
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mount.cifs free \
+		   strace mkfs free \
 		   which perl awk bc touch cut chmod true false unlink \
 		   mktemp getfattr setfattr chacl attr killall hexdump sync \
 		   id sort uniq date expr tac diff head dirname seq \
@@ -32,7 +33,8 @@ _rt_require_conf_dir FSTESTS_SRC
 		   chgrp du fgrep pgrep tar rev kill ip ping \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/* \
+		   $CIFS_UTILS_BINS" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "cifs ccm ctr" \

--- a/cut/fstests_cifs.sh
+++ b/cut/fstests_cifs.sh
@@ -16,7 +16,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_cifs.sh" "$@"
-_rt_require_fstests
+_rt_require_conf_dir FSTESTS_SRC
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mount.cifs free \

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -16,7 +16,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_xfs.sh" "$@"
-_rt_require_fstests
+_rt_require_conf_dir FSTESTS_SRC
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs free \

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -154,7 +154,7 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #BTRFS_PROGS_SRC=""
 #################################
 
-## autorun/fstests_cifs.sh and autorun/samba_*.sh ##
+## autorun/*cifs.sh and autorun/samba_*.sh ##
 # SMB server and mount options for cifs.ko
 # e.g. CIFS_SERVER="smbserver.example.com"
 #CIFS_SERVER=""
@@ -172,6 +172,13 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 # e.g. CIFS_PW="password"
 #CIFS_PW=""
 ####################################################
+
+######## cut/*cifs.sh ########
+# If CIFS_UTILS_SRC is set, then use (prebuilt) cifs-utils binaries from this
+# path instead of from the local system.
+# e.g. CIFS_UTILS_SRC="/home/me/cifs-utils"
+#CIFS_UTILS_SRC=""
+##############################
 
 ######## fstests_*.sh #########
 # FSTESTS_SRC should correspond to a checkout and build of the xfstests source

--- a/runtime.vars
+++ b/runtime.vars
@@ -166,6 +166,14 @@ _rt_require_btrfs_progs() {
 		|| _fail "missing btrfs-progs binaries"
 }
 
+_rt_require_cifs_utils() {
+	local which_bin="$(which which)"
+	local p="${CIFS_UTILS_SRC:-${PATH}:/sbin:/usr/sbin}"
+
+	CIFS_UTILS_BINS="$(PATH=$p $which_bin mount.cifs cifs.upcall)" \
+		|| _fail "missing cifs-utils binaries"
+}
+
 _rt_require_blktests() {
 	_rt_require_conf_dir BLKTESTS_SRC
 	[ -x "$BLKTESTS_SRC/check" ] || _fail "missing $BLKTESTS_SRC/check"

--- a/runtime.vars
+++ b/runtime.vars
@@ -161,11 +161,7 @@ _rt_require_fstests() {
 _rt_require_btrfs_progs() {
 	local which_bin="$(which which)"
 	# sbin paths search paths may be needed for non-root
-	local p="${PATH}:/sbin:/usr/sbin"
-
-	if [ -n "$BTRFS_PROGS_SRC" ]; then
-		p="${BTRFS_PROGS_SRC}"
-	fi
+	local p="${BTRFS_PROGS_SRC:-${PATH}:/sbin:/usr/sbin}"
 
 	BTRFS_PROGS_BINS="$(PATH=$p $which_bin \
 				mkfs.btrfs \

--- a/runtime.vars
+++ b/runtime.vars
@@ -153,11 +153,6 @@ _rt_write_ceph_bin_paths() {
 	echo "CEPH_FUSE_BIN=${CEPH_FUSE_BIN}" >> $vm_ceph_conf
 }
 
-_rt_require_fstests() {
-	_rt_require_conf_dir FSTESTS_SRC
-	[ -x "$FSTESTS_SRC/check" ] || _fail "missing $FSTESTS_SRC/check"
-}
-
 _rt_require_btrfs_progs() {
 	local which_bin="$(which which)"
 	# sbin paths search paths may be needed for non-root


### PR DESCRIPTION
Based atop https://github.com/rapido-linux/rapido/pull/155 , this series adds new cifs-krb cut/autorun scripts for testing cifs.ko kerberos authentication. A new `CIFS_UTILS_SRC` rapido.conf parameter is added to allow for testing `cifs.upcall` changes.