### PR TITLE
autorun/tcmu: properly fork tcmu-runner daemon

### DIFF
--- a/autorun/tcmu_file_iscsi.sh
+++ b/autorun/tcmu_file_iscsi.sh
@@ -37,7 +37,7 @@ mkdir -p /etc/tcmu
 echo > /etc/tcmu/tcmu.conf
 
 truncate --size $tcmu_dev_size "/${lu_name}.img"
-tcmu-runner -d --handler-path $TCMU_RUNNER_SRC &
+setsid --fork tcmu-runner -d --handler-path $TCMU_RUNNER_SRC
 sleep 1	# wait for tcmu-runner to start
 
 tcmu_backstore_setup() {

--- a/autorun/tcmu_rbd_loop.sh
+++ b/autorun/tcmu_rbd_loop.sh
@@ -52,7 +52,7 @@ echo > /etc/tcmu/tcmu.conf
 
 # LD_LIBRARY_PATH shouldn't be needed with the ld.so.conf entry, but it is.
 export LD_LIBRARY_PATH=${CEPH_SRC}/build/lib
-tcmu-runner -d --handler-path $TCMU_RUNNER_SRC &
+setsid --fork tcmu-runner -d --handler-path $TCMU_RUNNER_SRC
 
 [ -d $lio_cfgfs ] \
 	|| _fatal "$lio_cfgfs not present - LIO kernel modules not loaded?"


### PR DESCRIPTION
Running tcmu-runner as a simple bash background job means that ctrl-c
entries at the shell prompt result in SIGINT delivery and subsequent
tcmu-runner shutdown.
setsid is provided via Dracut's base module, so should always be used
for proper process daemonization.

Signed-off-by: David Disseldorp <ddiss@suse.de>