### PR TITLE
rdma: use the rdma tool

### DIFF
--- a/autorun/nvme_rdma.sh
+++ b/autorun/nvme_rdma.sh
@@ -53,7 +53,7 @@ modprobe zram num_devices="0"
 
 _vm_ar_dyn_debug_enable
 
-echo eth0 > /sys/module/rdma_rxe/parameters/add
+rdma link add rxe0 type rxe netdev eth0 || _fatal
 
 nvmet_cfs="/sys/kernel/config/nvmet/"
 nvmet_subsystem="nvmf-test"

--- a/cut/nvme_rdma.sh
+++ b/cut/nvme_rdma.sh
@@ -19,7 +19,7 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rdma.sh" "$@"
 _rt_require_lib "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs.xfs killall nvme ip ping \
+		   strace mkfs.xfs killall nvme ip ping rdma \
 		   $LIBS_INSTALL_LIST" \
 	$DRACUT_RAPIDO_INCLUDES \
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \


### PR DESCRIPTION
The 5.17-rcX kernel[1] has removed the module parameters, so
have to use the 'rdma' tool.

[1]: https://www.spinics.net/lists/linux-rdma/msg108004.html

Signed-off-by: Li Feng <fengli@smartx.com>