### PR TITLE
Introduce $KCONFIG: path for kconfig file (DRY)

### DIFF
--- a/cut/initramfs_verify.sh
+++ b/cut/initramfs_verify.sh
@@ -23,16 +23,11 @@ touch --date=@1641548270 "${tmp_vdata}/fiod"
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT" || _fail "dracut failed"
 
-if [[ -n $KERNEL_SRC ]]; then
-	kconfig="${KERNEL_SRC}/.config"
-else
-	kconfig="/boot/config-$(uname -r)"
-fi
 # As of 889d51a10712 (v2.6.28) kernel initramfs extraction preserves archived
 # mtimes by default.
 # Dracut doesn't always preserve directory mtimes through the staging area, so
 # append as a separate cpio archive.
-if ! grep -q "^# CONFIG_INITRAMFS_PRESERVE_MTIME" "$kconfig"; then
+if ! grep -q "^# CONFIG_INITRAMFS_PRESERVE_MTIME" "$KCONFIG"; then
 	mkdir -p "${tmp_vdata}/fiod.mtime_chk/2"
 	touch --date=@1641548271 "${tmp_vdata}/fiod.mtime_chk"
 	touch --date=@1641548272 "${tmp_vdata}/fiod.mtime_chk/2"

--- a/cut/ltp.sh
+++ b/cut/ltp.sh
@@ -19,12 +19,6 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/ltp.sh" "$@"
 _rt_require_conf_dir LTP_DIR
 _rt_mem_resources_set "2048M"	# 2 vCPUs, 2G RAM
 
-if [[ -n $KERNEL_SRC ]]; then
-	config="${KERNEL_SRC}/.config"
-else
-	config="/boot/config-$(uname -r)"
-fi
-
 "$DRACUT" \
 	--install " \
 		attr awk basename bc blockdev cat chattr chgrp chmod chown cmp cut \
@@ -38,7 +32,7 @@ fi
 		tee touch tr true truncate uniq unlink vgremove wc which xargs xxd yes \
 		${LTP_DIR}/bin/* ${LTP_DIR}/testcases/bin/*" \
 	--include "$LTP_DIR" "$LTP_DIR"  \
-	--include "$config" /.config \
+	--include "$KCONFIG" /.config \
 	--add-drivers "loop" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -13,6 +13,9 @@
 # "INSTALL_MOD_PATH=./mods make modules_install" during kernel compilation.
 #KERNEL_INSTALL_MOD_PATH="${KERNEL_SRC}/mods"
 
+# Kernel config is auto detected, but possible to overwrite if on unusual location.
+#KCONFIG=""
+
 ######### Host network settings #########
 # bridge device provisioned by "rapido setup-network".
 BR_DEV="rapido-br"

--- a/runtime.vars
+++ b/runtime.vars
@@ -16,6 +16,16 @@ RAPIDO_CONF="${RAPIDO_CONF:-${RAPIDO_DIR}/rapido.conf}"
 . $RAPIDO_CONF \
 	|| _fail "$RAPIDO_CONF processing failed - see rapido.conf.example"
 
+# kernel config path
+if [ -z "$KCONFIG" ]; then
+	if [ -n $KERNEL_SRC ]; then
+		KCONFIG="${KERNEL_SRC}/.config"
+	else
+		KCONFIG="/boot/config-$(uname -r)"
+	fi
+	[ -f "$KCONFIG" ] || _warn "missing kernel config (detected as $KCONFIG), configure it in KCONFIG variable"
+fi
+
 # initramfs output path
 DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
 


### PR DESCRIPTION
Currently cut/ltp.sh and cut/initramfs_verify.sh require kconfig path (possibly more in the future), therefore put it into runtime.vars.

Also warn if file missing.

NOTE: `$KCONFIG` is common variable for config on kernel testing tools (LTP and many others).