### PR TITLE
uring_btrfs: increase memory and bring up loopback

### DIFF
--- a/autorun/uring_btrfs.sh
+++ b/autorun/uring_btrfs.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LLC 2021, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2021-2022, all rights reserved.
 
 _vm_ar_env_check || exit 1
 
@@ -29,6 +19,9 @@ mount -t btrfs /dev/zram0 /mnt || _fatal
 chmod 777 /mnt || _fatal
 
 set +x
+
+# send_recvmsg test needs loopback networking
+ip link set dev lo up
 
 # liburing tests run from CWD so we unfortunately have to move them over
 mv ${LIBURING_SRC}/test /mnt || _fatal

--- a/cut/uring_btrfs.sh
+++ b/cut/uring_btrfs.sh
@@ -1,22 +1,13 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LLC 2021, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2021-2022, all rights reserved.
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/uring_btrfs.sh" "$@"
 _rt_require_conf_dir LIBURING_SRC
+_rt_mem_resources_set "2G"
 
 test_manifest="$(mktemp --tmpdir iouring_tests.XXXXX)"
 # remove tmp file once we're done
@@ -28,7 +19,7 @@ popd
 test_bins=$(sed "s#^#${LIBURING_SRC}/test/#" "$test_manifest")
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.btrfs tee timeout \
+		   strace mkfs mkfs.btrfs tee timeout ip \
 		   stat which touch cut chmod true false \
 		   id sort uniq date expr tac diff head dirname seq \
 		   ${LIBURING_SRC}/test/runtests.sh \


### PR DESCRIPTION
I'm seeing OOMs with liburing 2.1 on SLE15-SP4, so increase mem to 2G.
loopback is needed for the send_recvmsg test.

Signed-off-by: David Disseldorp <ddiss@suse.de>