### PR TITLE
runtime: use dracut cmdline hook instead of emergency

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -193,13 +193,14 @@ _rt_require_dracut_args() {
 	# destination filename.
 	local init_src=$1 init_dst kver
 
-	# specify core init scripts responsible for starting autorun
+	# Specify core init scripts responsible for starting autorun.
+	# The Dracut "cmdline" hook is executed prior to root parameter parsing.
 	local env_src="$RAPIDO_DIR/vm_autorun.env"
-	local emerg_src="$RAPIDO_DIR/autorun/00-rapido-init.sh"
-	local emerg_dst="/lib/dracut/hooks/emergency/00-rapido-init.sh"
+	local rinit_src="$RAPIDO_DIR/autorun/00-rapido-init.sh"
+	local rinit_dst="/lib/dracut/hooks/cmdline/00-rapido-init.sh"
 	DRACUT_RAPIDO_ARGS+=(--include "$RAPIDO_CONF" /rapido.conf \
-			     --include "$env_src" /.profile \
-			     --include "$emerg_src" "$emerg_dst")
+			     --include "$env_src" /etc/profile \
+			     --include "$rinit_src" "$rinit_dst")
 
 	# start at 100 and strip first digit on use - hack for zero-padding
 	local i=100

--- a/vm.sh
+++ b/vm.sh
@@ -23,8 +23,8 @@ _vm_start() {
 	local vm_resources=()
 	local vm_num_kparam="rapido.vm_num=${vm_num}"
 	local qemu_netdev=()
-	local kcmdline=(rd.systemd.unit=emergency.target \
-		rd.shell=1 "console=$QEMU_KERNEL_CONSOLE" \
+	local kcmdline=(rd.systemd.unit=dracut-cmdline.service \
+		"console=$QEMU_KERNEL_CONSOLE" \
 		$QEMU_EXTRA_KERNEL_PARAMS)
 
 	[ -f "$DRACUT_OUT" ] \


### PR DESCRIPTION
00-rapido-init.sh is currently installed as a Dracut emergency hook,
which gets invoked via:
```
  [ -z "$root" ] && die "No or empty root= argument"
  # die() later invokes emergency_shell() which invokes rapido-init
```
This means that we see a number of worrisome error messages before
rapido starts, e.g.
```
  [    0.789194] Run /init as init process
  [    0.860096] dracut: openSUSE Leap-15.3
  [    0.886398] dracut: FATAL: No or empty root= argument
  [    0.887587] dracut: Refusing to continue

  [    0.891465] dracut Warning:
  dracut Warning:

  Rapido: starting /rapido_autorun/00-simple_example.sh
```
With this change, 00-rapido-init.sh is invoked as a dracut cmdline hook
which is executed before "root=" cmdline processing, resulting in less
noise on the console, e.g.:
```
  [    0.706658] Run /init as init process
  [    0.774859] dracut: openSUSE Leap-15.3
  Rapido: starting /rapido_autorun/00-simple_example.sh
```
While testing with systemd I found that we also should be installing
vm_autorun.env under /etc/profile instead of /.profile; the latter
is reliant on a '/' home directory path.

Signed-off-by: David Disseldorp <ddiss@suse.de>