### PR TITLE
runtime: add and load virtio-rng / 9p modules on demand

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -191,7 +191,7 @@ _rt_require_dracut_args() {
 	# Multiple scripts can be specified and will be run in the order of
 	# parameters. This order is controlled by prepending an index to the
 	# destination filename.
-	local init_src=$1 init_dst kver
+	local init_src=$1 init_dst kver kmods=()
 
 	# Specify core init scripts responsible for starting autorun.
 	# The Dracut "cmdline" hook is executed prior to root parameter parsing.
@@ -244,6 +244,13 @@ _rt_require_dracut_args() {
 				|| _fail "missing $kmoddir"
 		DRACUT_RAPIDO_ARGS+=(--kmoddir "$kmoddir")
 	fi
+
+	[ "$QEMU_EXTRA_ARGS" == "${QEMU_EXTRA_ARGS/virtio-rng-pci}" ] \
+		|| kmods+=("virtio-rng")
+	[ -n "$VIRTFS_SHARE_PATH" ] && kmods+=("9pnet" "9pnet_virtio" "9p")
+	((${#kmods[*]} > 0)) \
+		&& DRACUT_RAPIDO_ARGS+=("--add-drivers" "${kmods[*]}")
+
 	# Append any rapido.conf user-defined parameters
 	DRACUT_RAPIDO_ARGS+=($DRACUT_EXTRA_ARGS)
 }

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -259,6 +259,16 @@ _vm_ar_ip_addrs_nomask() {
 	_vm_ar_ip_addrs "$1" "nomask"
 }
 
+_vm_ar_load_kmods() {
+	local -a kmods
+
+	[ "$QEMU_EXTRA_ARGS" == "${QEMU_EXTRA_ARGS/virtio-rng-pci}" ] \
+		|| kmods+=("virtio-rng")
+	[ -n "$VIRTFS_SHARE_PATH" ] && kmods+=("9pnet" "9pnet_virtio" "9p")
+	((${#kmods[*]} > 0)) && modprobe -a "${kmods[@]}"
+}
+
+_vm_ar_load_kmods
 _vm_kcli_param_get "rapido.vm_num"
 [ -z "$kcli_rapido_vm_num" ] && _fatal "rapido.vm_num missing in kcli"
 


### PR DESCRIPTION
If the virtio-rng and 9p virtfs modules aren't built-in (e.g. when
booting a distro kernel with KERNEL_SRC unset), then the modules need
to be explicitly added to the initramfs image and loaded on boot.

Do so if the corresponding virtio-rng or 9p functionality is requested
via QEMU_EXTRA_ARGS and / or VIRTFS_SHARE_PATH respectively.

Signed-off-by: David Disseldorp <ddiss@suse.de>