### PR TITLE
conf: Add default value for LTP_DIR

### DIFF
--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -253,8 +253,7 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 
 ########## cut/ltp.sh ##########
 # LTP_DIR should correspond to the ltp directory tree after make install.
-# e.g. LTP_DIR="/opt/ltp"
-#LTP_DIR=""
+LTP_DIR="/opt/ltp"
 #
 # XXX DEPRECATED: use the rapido cut '-x' or '-f' parameters instead
 # LTP_AUTORUN_CMD can be set to automatically run one or more testcases from


### PR DESCRIPTION
Most of users install LTP to the default prefix /opt/ltp,
therefore enable it by default (saves the need to change it for most of
users).