### PR TITLE
Selftest and uring changes

### DIFF
--- a/autorun/uring_xfs.sh
+++ b/autorun/uring_xfs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2021-2022, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+modprobe zram num_devices="1" || _fatal "failed to load zram module"
+
+_vm_ar_dyn_debug_enable
+
+echo "1G" > /sys/block/zram0/disksize || _fatal "failed to set zram disksize"
+
+mkfs.xfs /dev/zram0 || _fatal "mkfs failed"
+
+mkdir -p /mnt
+mount /dev/zram0 /mnt || _fatal
+chmod 777 /mnt || _fatal
+
+set +x
+
+# send_recvmsg test needs loopback networking
+ip link set dev lo up
+
+# liburing tests run from CWD so we unfortunately have to move them over
+mv ${LIBURING_SRC}/test /mnt || _fatal
+cd /mnt/test || _fatal
+cp /etc/passwd ./ || _fatal
+
+cat <<EOF
+To run a test:
+  ./runtests.sh <test_name>
+
+E.g. to run all tests on boot:
+  ./rapido cut -x './runtests.sh \$(cat /uring_tests.manifest)' uring-btrfs
+EOF

--- a/cut/uring_xfs.sh
+++ b/cut/uring_xfs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2021-2022, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/uring_xfs.sh" "$@"
+_rt_require_conf_dir LIBURING_SRC
+_rt_mem_resources_set "2G"
+
+test_manifest="$(mktemp --tmpdir iouring_tests.XXXXX)"
+trap "rm $test_manifest" 0 1 2 3 15
+
+test_files=( $(find "${LIBURING_SRC}/test" -type f -executable ! -name '*.sh' \
+		-fprintf "$test_manifest" '%f\n' -printf '%p ') )
+test_files+=("${LIBURING_SRC}/test/runtests.sh")
+[[ -f "${LIBURING_SRC}/test/config.local" ]] \
+	&& test_files+=("${LIBURING_SRC}/test/config.local")	# optional conf
+
+if [[ -d $KERNEL_SRC ]]; then
+	# add kernel iouring test tools if built via "make -C tools/io_uring"
+	for i in tools/io_uring/io_uring-bench tools/io_uring/io_uring-cp; do
+		[[ -x ${KERNEL_SRC}/${i} ]] && test_files+=("${KERNEL_SRC}/${i}")
+	done
+fi
+
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs mkfs.xfs tee timeout ip \
+		   stat which touch cut chmod true false \
+		   id sort uniq date expr tac diff head dirname seq \
+		   ${test_files[*]}" \
+	--include "$test_manifest" "/uring_tests.manifest" \
+	--add-drivers "xfs zram lzo lzo-rle" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/rapido
+++ b/rapido
@@ -153,18 +153,11 @@ rapido_help()
 }
 
 if [ "$#" = "0" ]; then
-	subcommand="help"
+	subcmd_func=rapido_help
 else
-	subcommand="$1"
+	subcmd_func=rapido_${1//-/_}
 	shift
 fi
-
-if ! declare -n subcmd=rapido_alias_${subcommand//-/_} &> /dev/null || \
-	test -z "${subcmd:-}"; then
-	subcmd="$subcommand"
-fi
-
-subcmd_func=rapido_${subcmd//-/_}
 if ! declare -f $subcmd_func > /dev/null; then
 	rapido_help
 	exit 1

--- a/selftest/selftest.sh
+++ b/selftest/selftest.sh
@@ -1,20 +1,11 @@
 #!/bin/bash
-#
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
 # Copyright (C) SUSE LLC 2019, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 export RAPIDO_SELFTEST_TMPDIR="$(mktemp -d rapido-selftest.XXXXXXX)"
+[ -d "$RAPIDO_SELFTEST_TMPDIR" ] || exit 1
 CLEANUP="rm -f ${RAPIDO_SELFTEST_TMPDIR}/*; rmdir $RAPIDO_SELFTEST_TMPDIR"
 # cleanup tmp dir when done
 trap "$CLEANUP" 0 1 2 3 15
@@ -34,7 +25,7 @@ _fail() {
 _generate_conf() {
 	local conf="$1"
 	local example_conf="${RAPIDO_DIR}/rapido.conf.example"
-	local i sed_regexp
+	local i val
 
 	[ -f "$conf" ] && _fail "$conf already exists, aborting"
 


### PR DESCRIPTION
```
The following changes since commit 24e3d1c868656561f3099c4d84253cbc35e60249:

  Merge branch 'ublk' (2022-09-05 10:00:38 +0200)

are available in the Git repository at:

  https://github.com/ddiss/rapido selftest_and_uring

for you to fetch changes up to acc5d014f74633903d616798119f1d2ec9a2f1c9:

  uring_xfs: add cut and autorun scripts (2022-09-24 00:03:17 +0200)

----------------------------------------------------------------
David Disseldorp (4):
      rapido: drop command alias handling
      selftest: minor cleanups
      cut/uring_btrfs: add config.local and kernel tests
      uring_xfs: add cut and autorun scripts

 autorun/uring_xfs.sh | 37 +++++++++++++++++++++++++++++++++++++
 cut/uring_btrfs.sh   | 20 +++++++++++++-------
 cut/uring_xfs.sh     | 37 +++++++++++++++++++++++++++++++++++++
 rapido               | 11 ++---------
 selftest/selftest.sh | 15 +++------------
 5 files changed, 92 insertions(+), 28 deletions(-)
 create mode 100755 autorun/uring_xfs.sh
 create mode 100755 cut/uring_xfs.sh
```