### PR TITLE
minor changes for nfsd-btrfs and new ssh-client runner

### DIFF
--- a/autorun/ssh_client.sh
+++ b/autorun/ssh_client.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2022, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+ssh -i "$SSH_IDENTITY" "$SSH_USER"@"$SSH_SERVER"

--- a/cut/nfsd_btrfs.sh
+++ b/cut/nfsd_btrfs.sh
@@ -17,7 +17,7 @@ _rt_mem_resources_set "$((2048 + (zram_bytes / 1048576)))M"
 		   id sort uniq date expr tac diff head dirname seq realpath \
 		   exportfs nfsdclddb nfsdclnts nfsdcltrack rcnfs-server \
 		   rpcbind rpc.mountd rpc.nfsd" \
-	--add-drivers "nfsd nfsv3 nfsv4 btrfs zram lzo lzo-rle" \
+	--add-drivers "nfsd btrfs zram lzo lzo-rle" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/ssh_client.sh
+++ b/cut/ssh_client.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2022, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/ssh_client.sh" "$@"
+_rt_require_networking
+
+[ -f "$SSH_KNOWN_HOSTS" ] && \
+	known_hosts=("--include" "$SSH_KNOWN_HOSTS" "/etc/ssh/ssh_known_hosts")
+
+"$DRACUT" \
+	--install "resize ps rmdir dd ssh /etc/ssh/ssh_config
+		   $SSH_IDENTITY ${SSH_IDENTITY}.pub" \
+	"${known_hosts[@]}" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -229,6 +229,22 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #TCMU_RUNNER_SRC=""
 #################################
 
+######### ssh_client.sh #########
+# server hostname / IP to use for ssh client connections
+#SSH_SERVER=""
+#
+# ssh client username
+#SSH_USER=""
+#
+# ssh client identity (private key) file, for which a public key is also
+# present at ${SSH_IDENTITY}.pub
+# e.g. SSH_IDENTITY="/home/me/.ssh/rapido_cli/id_rsa"
+#SSH_IDENTITY=""
+#
+# An optional file copied to /etc/ssh/ssh_known_hosts in the VM image
+#SSH_KNOWN_HOSTS=""
+#################################
+
 ###### autorun/dropbear.sh ######
 # public ssh key to add to Dropbear's authorized_keys file
 #SSH_AUTHORIZED_KEY=""

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -285,6 +285,6 @@ LTP_DIR="/opt/ltp"
 #NFS_SERVER=""
 #
 # mount options to use for NFS client mount attempts.
-#e.g. NFS_MOUNT_OPTIONS="nfsvers=3"
-#NFS_MOUNT_OPTIONS=""
+#e.g. NFS_MOUNT_OPTS="nfsvers=3"
+#NFS_MOUNT_OPTS=""
 ###############################################


### PR DESCRIPTION
```
      nfs: drop client kmods from server and fix conf typo
      ssh-client: add cut and autorun scripts

 autorun/ssh_client.sh |  7 +++++++
 cut/nfsd_btrfs.sh     |  2 +-
 cut/ssh_client.sh     | 20 ++++++++++++++++++++
 rapido.conf.example   | 20 ++++++++++++++++++--
 4 files changed, 46 insertions(+), 3 deletions(-)
 create mode 100755 autorun/ssh_client.sh
 create mode 100755 cut/ssh_client.sh
```