### PR TITLE
fstests: add and load virtio_blk kernel module

### DIFF
--- a/autorun/fstests_btrfs.sh
+++ b/autorun/fstests_btrfs.sh
@@ -7,6 +7,7 @@ _vm_ar_env_check || exit 1
 set -x
 
 [ -n "$BTRFS_PROGS_SRC" ] && export PATH="${PATH}:${BTRFS_PROGS_SRC}"
+modprobe virtio_blk
 modprobe zram num_devices=0 || _fatal "failed to load zram module"
 
 _vm_ar_hosts_create

--- a/autorun/fstests_exfat.sh
+++ b/autorun/fstests_exfat.sh
@@ -10,7 +10,7 @@ if [ -n "$EXFAT_PROGS_SRC" ]; then
 	export PATH="${PATH}:${EXFAT_PROGS_SRC}/mkfs:${EXFAT_PROGS_SRC}/fsck"
 	export PATH="${PATH}:${EXFAT_PROGS_SRC}/dump:${EXFAT_PROGS_SRC}/tune"
 fi
-
+modprobe virtio_blk
 modprobe zram num_devices="0" || _fatal "failed to load zram module"
 
 _vm_ar_hosts_create

--- a/autorun/fstests_ext4.sh
+++ b/autorun/fstests_ext4.sh
@@ -6,6 +6,7 @@ _vm_ar_env_check || exit 1
 
 set -x
 
+modprobe virtio_blk
 modprobe zram num_devices="0" || _fatal "failed to load zram module"
 
 _vm_ar_hosts_create

--- a/autorun/fstests_xfs.sh
+++ b/autorun/fstests_xfs.sh
@@ -6,6 +6,7 @@ _vm_ar_env_check || exit 1
 
 set -x
 
+modprobe virtio_blk
 modprobe zram num_devices="0" || _fatal "failed to load zram module"
 
 _vm_ar_hosts_create

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -33,7 +33,8 @@ _rt_mem_resources_set "$((3072 + (zram_bytes * 5 / 1048576)))M"
 		   $BTRFS_PROGS_BINS" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
-		       loop scsi_debug dm-log-writes xxhash_generic ext4" \
+		       loop scsi_debug dm-log-writes xxhash_generic ext4 \
+		       virtio_blk" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/fstests_exfat.sh
+++ b/cut/fstests_exfat.sh
@@ -33,7 +33,7 @@ _rt_mem_resources_set "$((2048 + (zram_bytes * 2 / 1048576)))M"
 		   $EXFAT_PROGS_BINS" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--add-drivers "zram lzo lzo-rle dm-flakey exfat \
-		       loop scsi_debug dm-log-writes" \
+		       loop scsi_debug dm-log-writes virtio_blk" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/fstests_ext4.sh
+++ b/cut/fstests_ext4.sh
@@ -33,7 +33,7 @@ _rt_mem_resources_set "$((2048 + (zram_bytes * 2 / 1048576)))M"
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--add-drivers "zram lzo lzo-rle dm-flakey ext4 \
-		       loop scsi_debug dm-log-writes" \
+		       loop scsi_debug dm-log-writes virtio_blk" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -31,7 +31,8 @@ _rt_mem_resources_set "$((2048 + (zram_bytes * 2 / 1048576)))M"
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
-	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey xfs" \
+	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey xfs \
+		       loop scsi_debug dm-log-writes virtio_blk" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT" || _fail "dracut failed"


### PR DESCRIPTION
This is required when using host-provided test/scratch block devices (feature added via https://github.com/rapido-linux/rapido/pull/170) on kernels built with CONFIG_VIRTIO_BLK=m. Rapido kconfigs in kernel/ specify CONFIG_VIRTIO_BLK=y, so this is mostly just for stock distro kernels.

cut/fstests_xfs.sh is updated to also pull in loop, scsi_debug and dm-log-writes kernel modules, which some tests desire.

Fixes: https://github.com/rapido-linux/rapido/issues/192
Signed-off-by: David Disseldorp <ddiss@suse.de>