### PR TITLE
fstests_udf: autorun and cut scripts

### DIFF
--- a/autorun/fstests_udf.sh
+++ b/autorun/fstests_udf.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+modprobe virtio_blk
+modprobe zram num_devices="0" || _fatal "failed to load zram module"
+
+_vm_ar_hosts_create
+_vm_ar_dyn_debug_enable
+
+xid="2000"	# xfstests requires a few preexisting users/groups
+for ug in fsgqa fsgqa2 123456-fsgqa; do
+	echo "${ug}:x:${xid}:${xid}:${ug} user:/:/sbin/nologin" >> /etc/passwd
+	echo "${ug}:x:${xid}:" >> /etc/group
+	((xid++))
+done
+
+fstests_cfg="${FSTESTS_SRC}/configs/$(hostname -s).config"
+cat > "$fstests_cfg" << EOF
+MODULAR=0
+TEST_DIR=/mnt/test
+SCRATCH_MNT=/mnt/scratch
+UDF_MKFS_OPTIONS="--utf8 --blocksize=4096 --media-type=hd"
+USE_KMEMLEAK=yes
+FSTYP=udf
+EOF
+[ -f "${FSTESTS_SRC}/src/udf_test" ] \
+	|| echo "DISABLE_UDF_TEST=1" >> "$fstests_cfg"
+_fstests_devs_provision "$fstests_cfg"
+. "$fstests_cfg"
+
+mkdir -p "$TEST_DIR" "$SCRATCH_MNT"
+mkudffs $UDF_MKFS_OPTIONS "$TEST_DEV" || _fatal "mkfs failed"
+mount -t "$FSTYP" "$TEST_DEV" "$TEST_DIR" || _fatal
+# xfstests can handle scratch mkfs+mount
+
+# fstests generic/131 needs loopback networking
+ip link set dev lo up
+
+set +x
+
+echo "$FSTYP filesystem ready for FSQA"
+
+cd "$FSTESTS_SRC" || _fatal
+if [ -n "$FSTESTS_AUTORUN_CMD" ]; then
+	eval "$FSTESTS_AUTORUN_CMD"
+fi

--- a/cut/fstests_udf.sh
+++ b/cut/fstests_udf.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/fstests.sh" \
+			"$RAPIDO_DIR/autorun/fstests_udf.sh" "$@"
+_rt_require_fstests
+_rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
+	|| _fail "failed to calculate memory resources"
+# 2x multiplier for one test and one scratch zram. +2G as buffer
+_rt_mem_resources_set "$((2048 + (zram_bytes * 2 / 1048576)))M"
+
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs shuf free ip \
+		   which perl awk bc touch cut chmod true false unlink \
+		   mktemp getfattr setfattr chacl attr killall hexdump sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   basename tee egrep yes mkswap timeout \
+		   fstrim fio logger dmsetup chattr lsattr cmp stat \
+		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		   repquota setquota quotacheck quotaon pvremove vgremove \
+		   xfs_mkfile xfs_db xfs_io wipefs filefrag losetup \
+		   chgrp du fgrep pgrep tar rev kill duperemove \
+		   swapon swapoff xfs_freeze fsck mkudffs \
+		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${FSTESTS_SRC}/src/log-writes/* \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	--add-drivers "zram lzo lzo-rle dm-flakey udf \
+		       loop scsi_debug dm-log-writes virtio_blk" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"


### PR DESCRIPTION
Very similar to other standalone fstests runners. Requires udftools (mkudffs) and udf kernel module dependencies. Uses a 4k block size inline with underlying zram block devices.

Signed-off-by: David Disseldorp <ddiss@suse.de>