### PR TITLE
Bug191: allow for sharing of RAPIDO_DIR between independent consumers

### DIFF
--- a/rapido
+++ b/rapido
@@ -105,7 +105,6 @@ rapido_cut()
 		exit
 	fi
 
-	rm -f "${RAPIDO_DIR}/initrds/myinitrd"
 	./$cut_script "${post_autorun_files[@]}"
 	local cut_status=$?
 	popd > /dev/null

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -67,6 +67,11 @@ QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 # Default is unset (i.e. use system dracut)
 #DRACUT_SRC=""
 
+# Initramfs output path for dracut when calling "rapido cut ...", used as input
+# image for QEMU boot. Default below need only be changed if RAPIDO_DIR is being
+# shared between independent users with different rapido configs.
+#DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
+
 # kernel modules or files for which dynamic debug should be enabled
 # e.g. DYN_DEBUG_MODULES="rbd libceph"
 # e.g. DYN_DEBUG_FILES="drivers/block/rbd.c"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -34,7 +34,10 @@ BR_ADDR="192.168.155.1/24"
 # e.g. TAP_USER="me"
 TAP_USER=""
 
-# VM network settings are read from the net-conf directory. See net-conf.example
+# VM network settings are read from the net-conf directory by default (see
+# net-conf.example). The default below need only be changed if RAPIDO_DIR is
+# being shared between independent users with different rapido configs.
+#VM_NET_CONF="${RAPIDO_DIR}/net-conf"
 #########################################
 
 # If specified, share this path with the guest via virtfs. It will be mounted

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -58,7 +58,7 @@ QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 # e.g. QEMU_EXTRA_KERNEL_PARAMS="loglevel=0"
 #QEMU_EXTRA_KERNEL_PARAMS=""
 
-# extra dracut args, e.g. "--debug --nostrip"
+# extra dracut args, e.g. "--debug --nostrip --tmpdir /tmp"
 #DRACUT_EXTRA_ARGS=""
 
 # Directory with dracut source code.

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -61,6 +61,15 @@ QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 # e.g. QEMU_EXTRA_KERNEL_PARAMS="loglevel=0"
 #QEMU_EXTRA_KERNEL_PARAMS=""
 
+# The directory to store QEMU pid files. When determining which identifier
+# (vm_num) to assign to a booting rapido VM, QEMU_PID_DIR is checked for
+# rapido_vm${vm_num}.pid files which correspond to an active process,
+# incrementing from vm_num=1. The first vm_num identifier found to not be
+# active is assigned to the booting VM.
+# You shouldn't need to change the default below unless RAPIDO_DIR is
+# being shared between independent users.
+#QEMU_PID_DIR="${RAPIDO_DIR}/initrds"
+
 # extra dracut args, e.g. "--debug --nostrip --tmpdir /tmp"
 #DRACUT_EXTRA_ARGS=""
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -226,7 +226,6 @@ _rt_require_dracut_args() {
 	# --confdir sees Dracut use rapido specific configuration, instead of
 	# processing /etc/dracut.conf.d/*.conf
 	DRACUT_RAPIDO_ARGS+=(--confdir "${RAPIDO_DIR}/dracut.conf.d" \
-			     --tmpdir "${RAPIDO_DIR}/initrds/" \
 			     --kver "$kver")
 
 	if [ -n "$DRACUT_SRC" ]; then

--- a/runtime.vars
+++ b/runtime.vars
@@ -11,13 +11,13 @@ _warn() {
 	echo "warning: $*"
 }
 
+# Dracut initramfs output path and QEMU input. Can be overridden in rapido.conf
+DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
+
 # process user defined configuration
 RAPIDO_CONF="${RAPIDO_CONF:-${RAPIDO_DIR}/rapido.conf}"
-. $RAPIDO_CONF \
+. "$RAPIDO_CONF" \
 	|| _fail "$RAPIDO_CONF processing failed - see rapido.conf.example"
-
-# initramfs output path
-DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
 
 _rt_ceph_src_globals_set() {
 	[ -d "$CEPH_SRC" ] || _fail "$CEPH_SRC is not a directory"

--- a/runtime.vars
+++ b/runtime.vars
@@ -14,6 +14,10 @@ _warn() {
 # Dracut initramfs output path and QEMU input. Can be overridden in rapido.conf
 DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
 
+# default VM network config path, also used for tap provisioning. Can be
+# overridden in rapido.conf
+VM_NET_CONF="${RAPIDO_DIR}/net-conf"
+
 # process user defined configuration
 RAPIDO_CONF="${RAPIDO_CONF:-${RAPIDO_DIR}/rapido.conf}"
 . "$RAPIDO_CONF" \
@@ -257,16 +261,15 @@ _rt_require_dracut_args() {
 _rt_require_networking() {
 	local netd="/usr/lib/systemd/systemd-networkd"
 	local netd_wait_online="/usr/lib/systemd/systemd-networkd-wait-online"
-	# a /etc/systemd/network -> net-conf/vm# symlink is created at runtime
-	# based on the vm# assigned and propagated via kernel cmdline.
-	local net_conf="${RAPIDO_DIR}/net-conf/"
+	# a /etc/systemd/network -> /rapido-rsc/net/vm# symlink is created at
+	# runtime based on the vm# assigned and propagated via kernel cmdline.
 
 	[ -x "$netd" ] || _fail "$netd is required for network-enabled images"
 	[ -x "$netd_wait_online" ] || _fail "$netd_wait_online missing"
-	[ -d "$net_conf" ] \
+	[ -d "$VM_NET_CONF" ] \
 		|| _fail "Network configuration required. See net-conf.example"
 	DRACUT_RAPIDO_ARGS+=(--install "ip ping $netd $netd_wait_online" \
-			     --include "$net_conf" /rapido-rsc/net \
+			     --include "$VM_NET_CONF" /rapido-rsc/net \
 			     --drivers "virtio_net af_packet")
 }
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -226,7 +226,7 @@ _rt_require_dracut_args() {
 	# --confdir sees Dracut use rapido specific configuration, instead of
 	# processing /etc/dracut.conf.d/*.conf
 	DRACUT_RAPIDO_ARGS+=(--confdir "${RAPIDO_DIR}/dracut.conf.d" \
-			     --kver "$kver")
+			     --force --kver "$kver")
 
 	if [ -n "$DRACUT_SRC" ]; then
 		DRACUT="$DRACUT_SRC/dracut.sh"

--- a/runtime.vars
+++ b/runtime.vars
@@ -11,11 +11,16 @@ _warn() {
 	echo "warning: $*"
 }
 
-# Dracut initramfs output path and QEMU input. Can be overridden in rapido.conf
+# Set a bunch of default parameter settings which may be overridden by the
+# subsequent RAPIDO_CONF include...
+
+# Dracut initramfs output path and QEMU input
 DRACUT_OUT="${RAPIDO_DIR}/initrds/myinitrd"
 
-# default VM network config path, also used for tap provisioning. Can be
-# overridden in rapido.conf
+# default directory to write QEMU pidfiles
+QEMU_PID_DIR="${RAPIDO_DIR}/initrds"
+
+# default VM network config path, also used for tap provisioning
 VM_NET_CONF="${RAPIDO_DIR}/net-conf"
 
 # process user defined configuration

--- a/selftest/selftest.sh
+++ b/selftest/selftest.sh
@@ -48,6 +48,7 @@ _generate_conf() {
 QEMU_EXTRA_KERNEL_PARAMS="loglevel=0"
 QEMU_EXTRA_ARGS="-monitor none -serial stdio -nographic -device virtio-rng-pci"
 DRACUT_OUT="${RAPIDO_SELFTEST_TMPDIR}/myinitrd"
+QEMU_PID_DIR="${RAPIDO_SELFTEST_TMPDIR}"
 EOF
 }
 

--- a/selftest/selftest.sh
+++ b/selftest/selftest.sh
@@ -4,7 +4,7 @@
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
-export RAPIDO_SELFTEST_TMPDIR="$(mktemp -d rapido-selftest.XXXXXXX)"
+export RAPIDO_SELFTEST_TMPDIR="$(mktemp --tmpdir -d rapido-selftest.XXXXXXX)"
 [ -d "$RAPIDO_SELFTEST_TMPDIR" ] || exit 1
 CLEANUP="rm -f ${RAPIDO_SELFTEST_TMPDIR}/*; rmdir $RAPIDO_SELFTEST_TMPDIR"
 # cleanup tmp dir when done
@@ -44,10 +44,11 @@ _generate_conf() {
 	done
 
 	# set QEMU_EXTRA_KERNEL_PARAMS= so that printk doesn't go to console
-	echo "QEMU_EXTRA_KERNEL_PARAMS=\"loglevel=0\"" >> "$conf" \
-		|| _fail "write failed"
-	echo "QEMU_EXTRA_ARGS=\"-monitor none -serial stdio -nographic -device virtio-rng-pci\"" \
-		>> "$conf" || _fail "write failed"
+	cat >> "$conf" <<EOF
+QEMU_EXTRA_KERNEL_PARAMS="loglevel=0"
+QEMU_EXTRA_ARGS="-monitor none -serial stdio -nographic -device virtio-rng-pci"
+DRACUT_OUT="${RAPIDO_SELFTEST_TMPDIR}/myinitrd"
+EOF
 }
 
 _run_tests() {

--- a/selftest/test/002
+++ b/selftest/test/002
@@ -1,16 +1,6 @@
 #!/usr/bin/expect -f
-#
-# Copyright (C) SUSE LLC 2019, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2019-2023, all rights reserved.
 
 # simple-example runner with separate cut + boot invocations
 
@@ -19,6 +9,16 @@ spawn ./rapido cut -B simple-example
 expect {
 	timeout {exit 1}
 	"dracut: *** Creating initramfs image file"
+}
+expect {
+	timeout {exit 1}
+	eof
+}
+# confirm that image was written at DRACUT_OUT path
+spawn lsinitrd $::env(RAPIDO_SELFTEST_TMPDIR)/myinitrd
+expect {
+	timeout {exit 1}
+	"Version: dracut"
 }
 expect {
 	timeout {exit 1}

--- a/selftest/test/003
+++ b/selftest/test/003
@@ -57,6 +57,24 @@ expect {
 	"rapido.vm_num=2"
 }
 
+# confirm that pid files are present
+set script "
+ps -p \"\$(head -n1 \"$::env(RAPIDO_SELFTEST_TMPDIR)/rapido_vm1.pid\")\" \
+	&& echo \"vm1 active\"
+ps -p \"\$(head -n1 \"$::env(RAPIDO_SELFTEST_TMPDIR)/rapido_vm2.pid\")\" \
+	&& echo \"vm2 active\"
+"
+spawn bash -c $script
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"vm1 active"
+}
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"vm2 active"
+}
+expect eof
+
 # shutdown first vm and wait for eof
 send -i $r1_sid "shutdown\r"
 expect {

--- a/selftest/test/005
+++ b/selftest/test/005
@@ -1,0 +1,34 @@
+#!/usr/bin/expect -f
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+# Check net-conf hostnames are propagated through to VMs
+
+set timeout 60
+
+set script "
+cp \"$::env(RAPIDO_CONF)\" \"$::env(RAPIDO_SELFTEST_TMPDIR)/005-rapido.conf\"
+echo VM_NET_CONF=\"$::env(RAPIDO_SELFTEST_TMPDIR)/005-net-conf\" \
+	>> \"$::env(RAPIDO_SELFTEST_TMPDIR)/005-rapido.conf\"
+mkdir -p \"$::env(RAPIDO_SELFTEST_TMPDIR)/005-net-conf/vm1\"
+echo \"vm1-test-005\" \
+	>> \"$::env(RAPIDO_SELFTEST_TMPDIR)/005-net-conf/vm1/hostname\"
+export RAPIDO_CONF=\"$::env(RAPIDO_SELFTEST_TMPDIR)/005-rapido.conf\"
+./rapido cut simple-example
+rm -rf \"$::env(RAPIDO_SELFTEST_TMPDIR)\"/005-*
+"
+
+spawn bash -c $script
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"Rapido scratch VM running. Have a lot of fun..."
+}
+
+send "cat /proc/sys/kernel/hostname\r"
+expect {
+	timeout {exit 1}; eof {exit 2}
+	"vm1-test-005"
+}
+send "shutdown\r"
+expect eof {exit 0}
+exit 5

--- a/tools/br_tap_setup.sh
+++ b/tools/br_tap_setup.sh
@@ -36,14 +36,14 @@ _tap_manifest_gen() {
 	br_dev="$2"
 	local i vm_tap
 
-	[[ -d ${RAPIDO_DIR}/net-conf ]] \
-		|| fail "net-conf directory missing, see net-conf.example"
+	[[ -d $VM_NET_CONF ]] \
+		|| fail "$VM_NET_CONF directory missing, see net-conf.example"
 
 	cat > "$manifest" << EOF
 # The following tap devices will be created alongside "${br_dev}":
 EOF
 	shopt -s nullglob
-	for i in ${RAPIDO_DIR}/net-conf/vm[0-9]*/*.network; do
+	for i in ${VM_NET_CONF}/vm[0-9]*/*.network; do
 		[[ $i =~ /vm[0-9]*/(.*)\.network$ ]] || continue
 		vm_tap="${BASH_REMATCH[1]}"
 		if [[ -d /sys/class/net/${vm_tap} ]]; then

--- a/tools/br_tap_teardown.sh
+++ b/tools/br_tap_teardown.sh
@@ -72,10 +72,10 @@ done
 
 if [[ -n $BR_DHCP_SRV_RANGE ]]; then
 	# FIXME should be able to use /var/run/rapido-dnsmasq-$$.pid
-	dnsmasq_pid=`ps -eo pid,args | grep -v grep | grep dnsmasq \
-			| grep -- --interface=$br_name \
-			| grep -- --dhcp-range=$BR_DHCP_SRV_RANGE \
-			| awk '{print $1}'`
+	# TODO deprecate in favour of networkd [DHCPServer] on vm
+	dnsmasq_pid=$(ps -eo pid,args \
+		| awk '$2 ~ /dnsmasq/ && /--interface='"$br_name"'/ \
+			&& /--dhcp-range='"$BR_DHCP_SRV_RANGE"'/ { print $1 }')
 	if [ -z "$dnsmasq_pid" ]; then
 		echo "failed to find dnsmasq process"
 		#exit 1

--- a/tools/br_tap_teardown.sh
+++ b/tools/br_tap_teardown.sh
@@ -30,14 +30,14 @@ _tap_manifest_gen() {
 	br_dev="$2"
 	local i vm_tap
 
-	[[ -d ${RAPIDO_DIR}/net-conf ]] \
-		|| fail "net-conf directory missing, see net-conf.example"
+	[[ -d $VM_NET_CONF ]] \
+		|| fail "$VM_NET_CONF directory missing, see net-conf.example"
 
 	cat > "$manifest" << EOF
 # The following tap devices will be deleted alongside "${br_dev}":
 EOF
 	shopt -s nullglob
-	for i in ${RAPIDO_DIR}/net-conf/vm[0-9]*/*.network; do
+	for i in ${VM_NET_CONF}/vm[0-9]*/*.network; do
 		[[ $i =~ /vm[0-9]*/(.*)\.network$ ]] || continue
 		vm_tap="${BASH_REMATCH[1]}"
 		if [[ -d /sys/class/net/${vm_tap} ]]; then

--- a/tools/net_conf_migrate.sh
+++ b/tools/net_conf_migrate.sh
@@ -113,7 +113,7 @@ for i in 1 2; do
 done
 
 cat << EOF
--> Complete: inspect then run "mv ${tmpd##*/} net-conf" to activate the config.
+-> Complete: inspect then run "mv ${tmpd##*/} $VM_NET_CONF" to activate the config.
 -> rapido.conf MAC_ADDR, TAP_DEV, HOSTNAME and IP_ADDR options can then be removed.
 EOF
 

--- a/tools/podman-import-initramfs.sh
+++ b/tools/podman-import-initramfs.sh
@@ -18,7 +18,7 @@ t=$(mktemp --directory "rapido-cpio-to-tar.XXXXXXXXXX")
 unwind="rm -rf \"${t}\"; $unwind"
 
 # "podman import" doesn't natively support cpio so we need to transcode to tar
-cpio -D "$t" -idm < ${RAPIDO_DIR}/initrds/myinitrd \
+cpio -D "$t" -idm < "$DRACUT_OUT" \
 	|| _fail "failed to extract image at ${RAPIDO_DIR}/initrds/myinitrd"
 
 tar -C "$t" --to-stdout -c . | podman import -m="Imported from rapido" "$@" - \

--- a/vm.sh
+++ b/vm.sh
@@ -9,7 +9,7 @@ _rt_require_qemu_args
 
 _vm_is_running() {
 	local vm_num=$1
-	local vm_pid_file="${RAPIDO_DIR}/initrds/rapido_vm${vm_num}.pid"
+	local vm_pid_file="${QEMU_PID_DIR}/rapido_vm${vm_num}.pid"
 
 	[ -f $vm_pid_file ] || return
 
@@ -18,7 +18,7 @@ _vm_is_running() {
 
 _vm_start() {
 	local vm_num=$1
-	local vm_pid_file="${RAPIDO_DIR}/initrds/rapido_vm${vm_num}.pid"
+	local vm_pid_file="${QEMU_PID_DIR}/rapido_vm${vm_num}.pid"
 	local netd_flag netd_mach_id i vm_tap tap_mac n f
 	local vm_resources=()
 	local vm_num_kparam="rapido.vm_num=${vm_num}"


### PR DESCRIPTION
This patchset attempt to remove all hardcoded `RAPIDO_DIR` paths for configuration and output files, making it much easier for independent CI jobs to run on the same host without the need to clone separate rapido repositories.

```
The following changes since commit 8571d3aa651f552f6eb735931397e3fd7e13e12a:

  Merge branch 'udf_v2' (2023-01-25 00:04:03 +0100)

are available in the Git repository at:

  https://github.com/ddiss/rapido bug191_share_RAPIDO_DIR

for you to fetch changes up to 8a88b9d38598ade9c33889bc3312d9bda914f30a:

  selftest/003: test QEMU_PID_DIR (2023-01-27 00:29:45 +0100)

----------------------------------------------------------------
David Disseldorp (9):
      runtime.vars: drop hardcoded dracut tmpdir
      Revert "rapido: remove existing image instead of using dracut --force"
      tools/br_tap_teardown.sh: clean up dnsmasq pid lookup
      runtime.vars: allow DRACUT_OUT to be changed in rapido.conf
      rapido.conf: add VM_NET_CONF parameter
      selftest: check for image at non-default DRACUT_OUT path
      selftest/005: test VM_NET_CONF paths and hostname propagation
      rapido.conf: add QEMU_PID_DIR parameter
      selftest/003: test QEMU_PID_DIR

 rapido                           |  1 -
 rapido.conf.example              | 21 +++++++++++++++++++--
 runtime.vars                     | 29 ++++++++++++++++++-----------
 selftest/selftest.sh             | 12 +++++++-----
 selftest/test/002                | 24 ++++++++++++------------
 selftest/test/003                | 18 ++++++++++++++++++
 selftest/test/005                | 34 ++++++++++++++++++++++++++++++++++
 tools/br_tap_setup.sh            |  6 +++---
 tools/br_tap_teardown.sh         | 14 +++++++-------
 tools/net_conf_migrate.sh        |  2 +-
 tools/podman-import-initramfs.sh |  2 +-
 vm.sh                            | 15 ++++++++-------
 12 files changed, 128 insertions(+), 50 deletions(-)
 create mode 100755 selftest/test/005
```