### PR TITLE
new OCFS2 runner and system samba support

### DIFF
--- a/autorun/lib/samba.sh
+++ b/autorun/lib/samba.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+_samba_paths_init() {
+	local conf_file="$1" state="search" d=() key dir
+	[ -n "$SAMBA_SRC" ] && export PATH="${SAMBA_SRC}/bin/:${PATH}"
+
+	while [[ $state != "end" ]] && read -r key dir; do
+		if [[ $key == "Paths:" ]]; then
+			state="paths"
+			continue
+		fi
+		[[ $state == "paths" ]] || continue;
+		case "$key" in
+		"")
+			state="end"
+			;;
+		LOGFILEBASE:)
+			echo "Log at: ${dir}/log.smbd"
+			d+=("$dir")
+			;;
+		*DIR:)
+			if [[ $key == "MODULESDIR:" && -d "$SAMBA_SRC" ]]; then
+			    ln -s "${SAMBA_SRC}/bin/modules/vfs/" "${dir}/vfs" \
+				|| _fatal "failed to symlink vfs modules"
+			fi
+			d+=("$dir")
+			;;
+		esac
+	done < <(smbd -b -s "$conf_file") \
+		|| _fatal "failed to get smbd build options"
+	(( ${#d[*]} > 0 )) && mkdir -p "${d[@]}"
+}

--- a/autorun/ocfs2.sh
+++ b/autorun/ocfs2.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+_vm_ar_env_check || exit 1
+modprobe -a ocfs2 virtio_blk || _fatal
+_vm_ar_dyn_debug_enable
+
+mkdir -p /etc/ocfs2 /mnt/ocfs2
+
+# add the first IP for each network-configured rapido VM
+for ((node = 1; node < 10; node++)); do
+	node_ips=()
+	_vm_ar_cfg_ips_nomask "$node" node_ips
+	if (( ${#node_ips[*]} == 0 )); then
+		break
+	elif (( ${#node_ips[*]} > 1 )); then
+		echo "only using first IP (${node_ips[0]}) for vm $node"
+	fi
+
+	cat >> /etc/ocfs2/cluster.conf <<EOF
+node:
+	ip_port = 7777
+	ip_address = ${node_ips[0]}
+	number = $node
+	name = rapido${node}
+	cluster = rapidocluster
+EOF
+done
+
+cat >> /etc/ocfs2/cluster.conf <<EOF
+cluster:
+	node_count = $((node - 1))
+	name = rapidocluster
+EOF
+
+# expect a device with serial=OCFS2
+declare -A _CFG=(["OCFS2"]="")
+for i in $(ls /sys/block); do
+	ser="$(cat /sys/block/${i}/serial 2>/dev/null)" || continue
+	[[ -v "_CFG[$ser]" ]] && _CFG[$ser]="/dev/${i}"
+done
+
+[ -b "${_CFG[OCFS2]}" ] || _fatal "block device with serial=OCFS2 required"
+
+# configfs needed for o2cb
+_vm_ar_configfs_mount
+
+set -x
+o2cb register-cluster rapidocluster || _fatal
+
+# first rapido VM does the mkfs
+if (( $kcli_rapido_vm_num == 1 )); then
+	# mkfs manually prompts before overwrite and returns 1 on 'n', so
+	# ignore failure here. IO errors should anyhow be caught by mount.
+	mkfs.ocfs2 --force "${_CFG[OCFS2]}"
+fi
+
+mount "${_CFG[OCFS2]}" /mnt/ocfs2 || _fatal
+set +x

--- a/autorun/samba_kernel_cephfs.sh
+++ b/autorun/samba_kernel_cephfs.sh
@@ -1,24 +1,12 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LINUX GmbH 2019, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2019-2023, all rights reserved.
 
 _vm_ar_env_check || exit 1
 
 set -x
 
 _vm_ar_dyn_debug_enable
-
-export PATH="${SAMBA_SRC}/bin/:${PATH}"
 
 # use a uid and gid which match the CephFS root owner, so SMB users can perform
 # I/O without needing to chmod.
@@ -30,14 +18,8 @@ mkdir -p /mnt/cephfs
 mount -t ceph ${CEPH_MON_ADDRESS_V1}:/ /mnt/cephfs \
 	-o name=${CEPH_USER},secret=${CEPH_USER_KEY} || _fatal
 
-mkdir -p /usr/local/samba/var/
-mkdir -p /usr/local/samba/etc/
-mkdir -p /usr/local/samba/var/lock
-mkdir -p /usr/local/samba/private/
-mkdir -p /usr/local/samba/lib/
-ln -s ${SAMBA_SRC}/bin/modules/vfs/ /usr/local/samba/lib/vfs
-
-cat > /usr/local/samba/etc/smb.conf << EOF
+cfg_file="/smb.conf"
+cat > "$cfg_file" << EOF
 [global]
 	workgroup = MYGROUP
 	load printers = no
@@ -52,16 +34,16 @@ cat > /usr/local/samba/etc/smb.conf << EOF
 	oplocks = no
 EOF
 
-smbd || _fatal
-
 set +x
+_samba_paths_init "$cfg_file"
+
+smbd -s "$cfg_file" || _fatal
 
 echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
-	| smbpasswd -a $CIFS_USER -s || _fatal
+	| smbpasswd -c "$cfg_file" -a $CIFS_USER -s || _fatal
 
 pub_ips=()
 _vm_ar_ip_addrs_nomask pub_ips
 for i in "${pub_ips[@]}"; do
 	echo "Samba share ready at: //${i}/${CIFS_SHARE}/"
 done
-echo "Log at: /usr/local/samba/var/log.smbd"

--- a/cut/ocfs2.sh
+++ b/cut/ocfs2.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/ocfs2.sh" "$@"
+_rt_require_networking
+_rt_mem_resources_set "1024M"
+
+[[ $QEMU_EXTRA_ARGS =~ serial=OCFS2([, ]|$) ]] || _fail "$(cat <<EOF
+This runner requires one shared block device between all VMs, with "OCFS2"
+as device serial identifier, e.g.
+QEMU_EXTRA_ARGS="... -drive if=none,id=o2,file=/tmp/o2dev,cache=none,format=raw,file.locking=off -device virtio-blk-pci,drive=o2,serial=OCFS2"
+EOF
+)"
+
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df \
+		   strace xargs timeout \
+		   which awk touch cut chmod true false \
+		   getfattr setfattr chacl attr killall sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   o2cb mkfs.ocfs2 mount.ocfs2 fsck.ocfs2" \
+	--modules "base" \
+	--drivers "virtio_blk ocfs2 ocfs2_stack_o2cb ocfs2_dlm dlm" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LINUX GmbH 2017, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2017-2023, all rights reserved.
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
@@ -19,12 +9,12 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/samba_cephfs.sh" \
-			"$@"
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lib/samba.sh" \
+			"$RAPIDO_DIR/autorun/samba_cephfs.sh" "$@"
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_conf_dir SAMBA_SRC
+_rt_require_samba_srv "vfs/ceph.so"
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 # assign more memory
@@ -34,11 +24,7 @@ _rt_mem_resources_set "1024M"
 		   which touch cut chmod true false \
 		   getfattr setfattr chacl attr killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   ${SAMBA_SRC}/bin/smbpasswd \
-		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/modules/vfs/ceph.so \
-		   ${SAMBA_SRC}/bin/smbd \
-		   $LIBS_INSTALL_LIST" \
+		   $SAMBA_SRV_BINS $LIBS_INSTALL_LIST" \
 	--include "$CEPH_COMMON_LIB" "/usr/lib64/libceph-common.so.0" \
 	--include "$CEPHFS_LIB" "/usr/lib64/libcephfs.so.2" \
 	--include "$CEPH_RADOS_LIB" "/usr/lib64/librados.so.2" \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LINUX GmbH 2019, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2019-2023, all rights reserved.
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
@@ -19,12 +9,12 @@ vm_ceph_conf="$(mktemp --tmpdir vm_ceph_conf.XXXXX)"
 # remove tmp file once we're done
 trap "rm $vm_ceph_conf" 0 1 2 3 15
 
-_rt_require_dracut_args "$vm_ceph_conf" \
+_rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lib/samba.sh" \
 			"$RAPIDO_DIR/autorun/samba_kernel_cephfs.sh" "$@"
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config "$vm_ceph_conf"
-_rt_require_conf_dir SAMBA_SRC
+_rt_require_samba_srv
 # assign more memory
 _rt_mem_resources_set "1024M"
 
@@ -32,9 +22,7 @@ _rt_mem_resources_set "1024M"
 		   strace stat which touch cut chmod true false \
 		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   ${SAMBA_SRC}/bin/smbpasswd \
-		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/smbd" \
+		   $SAMBA_SRV_BINS" \
 	--add-drivers "ceph libceph" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -1,35 +1,23 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LINUX GmbH 2017, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2017-2023, all rights reserved.
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/samba_local.sh" "$@"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/samba.sh" \
+			"$RAPIDO_DIR/autorun/samba_local.sh" "$@"
 _rt_require_networking
-_rt_require_conf_dir SAMBA_SRC
+_rt_require_samba_srv "vfs/btrfs.so"
 # assign more memory
 _rt_mem_resources_set "1024M"
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
-		   strace mkfs mkfs.btrfs mkfs.xfs \
+		   strace mkfs mkfs.btrfs mkfs.xfs awk dirname \
 		   stat which touch cut chmod true false \
 		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   ${SAMBA_SRC}/bin/smbpasswd \
-		   ${SAMBA_SRC}/bin/smbstatus \
-		   ${SAMBA_SRC}/bin/modules/vfs/btrfs.so \
-		   ${SAMBA_SRC}/bin/smbd" \
+		   $SAMBA_SRV_BINS" \
 	--add-drivers "zram lzo lzo-rle xfs btrfs" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \

--- a/runtime.vars
+++ b/runtime.vars
@@ -190,6 +190,28 @@ _rt_require_exfat_progs() {
 		|| _fail "missing exfat_progs binaries"
 }
 
+_rt_require_samba_srv() {
+	local p="${PATH}:/sbin:/usr/sbin"
+	local mods_p="/usr/lib64/samba"
+
+	if [ -n "$SAMBA_SRC" ]; then
+		p="${SAMBA_SRC}/bin"
+		mods_p="${SAMBA_SRC}/bin/modules"
+	fi
+
+	# any parameters are treated as extra modules
+	local mods=("${mods_p}/pdb/tdbsam.so")
+	while (( $# > 0 )) ; do
+		[ -f "${mods_p}/${1}" ] || _fatal "Samba module $1 missing"
+		mods+=("${mods_p}/${1}")
+		shift
+	done
+
+	SAMBA_SRV_BINS="$(PATH=$p type -P smbpasswd smbstatus smbd)" \
+		|| _fail "missing samba server binaries"
+	SAMBA_SRV_BINS="$SAMBA_SRV_BINS ${mods[*]}"
+}
+
 _rt_require_blktests() {
 	_rt_require_conf_dir BLKTESTS_SRC
 	[ -x "$BLKTESTS_SRC/check" ] || _fail "missing $BLKTESTS_SRC/check"


### PR DESCRIPTION
```
The following changes since commit 535d0debee33887a4202905500fe7e322168f491:

  Merge remote-tracking branch 'me-gh/cifs_kmods' (2023-02-14 21:39:48 +0100)

are available in the Git repository at:

  https://github.com/ddiss/rapido/ ocfs2_and_system_samba

for you to fetch changes up to 9f5fa7c2be4cb9cd7b9ba4347eff5a2aaf9c90b2:

  ocfs2: add cut and autorun scripts (2023-02-17 17:07:28 +0100)

----------------------------------------------------------------
David Disseldorp (2):
      samba: support use of locally installed samba binaries
      ocfs2: add cut and autorun scripts

 autorun/lib/samba.sh           | 34 ++++++++++++++++++++++++
 autorun/ocfs2.sh               | 60 ++++++++++++++++++++++++++++++++++++++++++
 autorun/samba_cephfs.sh        | 34 ++++++------------------
 autorun/samba_kernel_cephfs.sh | 34 ++++++------------------
 autorun/samba_local.sh         | 33 ++++++-----------------
 cut/ocfs2.sh                   | 28 ++++++++++++++++++++
 cut/samba_cephfs.sh            | 26 +++++-------------
 cut/samba_kernel_cephfs.sh     | 22 ++++------------
 cut/samba_local.sh             | 26 +++++-------------
 runtime.vars                   | 22 ++++++++++++++++
 10 files changed, 186 insertions(+), 133 deletions(-)
 create mode 100644 autorun/lib/samba.sh
 create mode 100755 autorun/ocfs2.sh
 create mode 100755 cut/ocfs2.sh
```