### PR TITLE
fstests_ntfs3 and ksmbd: add cut and autorun scripts

### DIFF
--- a/autorun/fstests_ntfs3.sh
+++ b/autorun/fstests_ntfs3.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+# create mkfs symlink for xfstests, which assumes mkfs.$FSTYPE
+mkfsbin="$(type -P mkfs.ntfs)"
+ln -s "${mkfsbin}" "${mkfsbin}3" || break
+
+modprobe virtio_blk
+modprobe zram num_devices="0" || _fatal "failed to load zram module"
+
+_vm_ar_hosts_create
+_vm_ar_dyn_debug_enable
+
+_fstests_users_groups_provision
+
+fstests_cfg="${FSTESTS_SRC}/configs/$(hostname -s).config"
+cat > "$fstests_cfg" << EOF
+MODULAR=0
+TEST_DIR=/mnt/test
+SCRATCH_MNT=/mnt/scratch
+USE_KMEMLEAK=yes
+FSTYP=ntfs3
+EOF
+_fstests_devs_provision "$fstests_cfg"
+. "$fstests_cfg"
+
+mkdir -p "$TEST_DIR" "$SCRATCH_MNT"
+mkfs."${FSTYP}" "$TEST_DEV" || _fatal "mkfs failed"
+mount -t "$FSTYP" "$TEST_DEV" "$TEST_DIR" || _fatal
+# xfstests can handle scratch mkfs+mount
+
+# fstests generic/131 needs loopback networking
+ip link set dev lo up
+
+set +x
+
+echo "$FSTYP filesystem ready for FSQA"
+
+cd "$FSTESTS_SRC" || _fatal
+if [ -n "$FSTESTS_AUTORUN_CMD" ]; then
+	eval "$FSTESTS_AUTORUN_CMD"
+fi
+

--- a/autorun/ksmbd_btrfs.sh
+++ b/autorun/ksmbd_btrfs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2017-2023, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+set -x
+modprobe zram num_devices="1" || _fatal "failed to load zram module"
+modprobe ksmbd
+_vm_ar_dyn_debug_enable
+
+# ksmbd utilities are currently all symlinks to ksmbd.tools
+for i in ksmbd.addshare ksmbd.adduser ksmbd.control ksmbd.mountd; do
+	p="${PATH}:/usr/libexec:/sbin:/usr/sbin"
+        if [ -n "$KSMBD_TOOLS_SRC" ]; then
+		p="${KSMBD_TOOLS_SRC}/tools"
+        fi
+	ln -s $(PATH=$p type -P ksmbd.tools) /sbin/${i}
+done
+
+# use a non-configurable UID/GID for now
+cifs_xid="579120"
+echo "${CIFS_USER}:x:${cifs_xid}:${cifs_xid}:Samba user:/:/sbin/nologin" \
+	>> /etc/passwd
+echo "${CIFS_USER}:x:${cifs_xid}:" >> /etc/group
+
+echo "${FSTESTS_ZRAM_SIZE:-1G}" > /sys/block/zram0/disksize \
+	|| _fatal "failed to set zram disksize"
+mkfs.btrfs /dev/zram0 || _fatal "mkfs failed"
+mkdir -p /mnt/ /etc/ksmbd
+mount -t btrfs /dev/zram0 /mnt/ || _fatal
+chmod 777 /mnt/ || _fatal
+
+cfg_file="/etc/ksmbd/ksmbd.conf"
+users_db="/etc/ksmbd/ksmbdpwd.db"
+
+cat > "$cfg_file" << EOF
+[global]
+	workgroup = MYGROUP
+
+[${CIFS_SHARE}]
+	path = /mnt
+	read only = no
+	store dos attributes = yes
+EOF
+
+ksmbd.mountd -c "$cfg_file" -u "$users_db" \
+	|| _fatal "failed to start ksmbd.mountd"
+set +x
+echo -e "${CIFS_PW}\n${CIFS_PW}\n" \
+	| ksmbd.adduser -a "$CIFS_USER" -c "$cfg_file" -i "$users_db" \
+		|| _fatal "failed to add ksmbd user"
+
+pub_ips=()
+_vm_ar_ip_addrs_nomask pub_ips
+for i in "${pub_ips[@]}"; do
+	echo "ksmbd share ready at: //${i}/${CIFS_SHARE}/"
+done

--- a/cut/fstests_ntfs3.sh
+++ b/cut/fstests_ntfs3.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/fstests.sh" \
+			"$RAPIDO_DIR/autorun/fstests_ntfs3.sh" "$@"
+_rt_require_fstests
+req_paths=()
+_rt_require_pam_mods req_paths "pam_rootok.so" "pam_limits.so"
+_rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
+	|| _fail "failed to calculate memory resources"
+# 2x multiplier for one test and one scratch zram. +2G as buffer
+_rt_mem_resources_set "$((2048 + (zram_bytes * 2 / 1048576)))M"
+
+# install mkfs.ntfs from ntfsprogs (3g), excluding the FUSE module, etc.
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs shuf free ip su \
+		   which perl awk bc touch cut chmod true false unlink \
+		   mktemp getfattr setfattr chacl attr killall hexdump sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   basename tee egrep yes mkswap timeout \
+		   fstrim fio logger dmsetup chattr lsattr cmp stat \
+		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		   repquota setquota quotacheck quotaon pvremove vgremove \
+		   xfs_mkfile xfs_db xfs_io wipefs filefrag losetup \
+		   chgrp du fgrep pgrep tar rev kill duperemove \
+		   swapon swapoff xfs_freeze fsck mkfs.ntfs ${req_paths[*]} \
+		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${FSTESTS_SRC}/src/log-writes/* \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	--add-drivers "zram lzo lzo-rle dm-flakey ntfs3 \
+		       loop scsi_debug dm-log-writes virtio_blk" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/ksmbd_btrfs.sh
+++ b/cut/ksmbd_btrfs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/ksmbd_btrfs.sh" "$@"
+_rt_require_networking
+req_inst=()
+_rt_require_ksmbd_tools req_inst
+_rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
+	|| _fail "failed to calculate memory resources"
+_rt_mem_resources_set "$((1024 + (zram_bytes / 1048576)))M"
+
+"$DRACUT" --install "tail ps rmdir resize dd grep find df sha256sum \
+		   strace mkfs mkfs.btrfs awk dirname \
+		   stat which touch cut chmod true false \
+		   getfattr setfattr getfacl setfacl killall sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   ${req_inst[*]}" \
+	--add-drivers "btrfs zram lzo lzo-rle \
+		       ksmbd ecb hmac md5 aes cmac sha256 sha512 ccm \
+		       gcm crc32" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -273,6 +273,13 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #SAMBA_SRC=""
 #################################
 
+############# ksmbd #############
+# By default ksmbd-tools binaries will be obtained from the local system. If
+# set, KSMBD_TOOLS_SRC should correspond to a checkout and build of the
+# source available from https://github.com/cifsd-team/ksmbd-tools.
+#KSMBD_TOOLS_SRC=""
+#################################
+
 ########## cut/lrbd.sh #########
 # These should all correspond to checked-out source repositories
 #LRBD_SRC=""

--- a/runtime.vars
+++ b/runtime.vars
@@ -212,6 +212,18 @@ _rt_require_samba_srv() {
 	SAMBA_SRV_BINS="$SAMBA_SRV_BINS ${mods[*]}"
 }
 
+_rt_require_ksmbd_tools() {
+	declare -n req_inst_ref="$1" || _fail "output ref parameter required"
+	local p="${PATH}:/usr/libexec:/sbin:/usr/sbin"
+
+	if [ -n "$KSMBD_TOOLS_SRC" ]; then
+		p="${KSMBD_TOOLS_SRC}/tools"
+	fi
+
+	req_inst_ref+=( $(PATH=$p type -P ksmbd.tools) ) \
+		|| _fail "missing ksmbd.tools binary"
+}
+
 _rt_require_blktests() {
 	_rt_require_conf_dir BLKTESTS_SRC
 	[ -x "$BLKTESTS_SRC/check" ] || _fail "missing $BLKTESTS_SRC/check"


### PR DESCRIPTION
This makes use of the mkfs.ntfs binary from the ntfs-3g project.