### PR TITLE
Drop some globals

### DIFF
--- a/cut/cephfs_fuse.sh
+++ b/cut/cephfs_fuse.sh
@@ -25,14 +25,15 @@ _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_write_ceph_bin_paths $vm_ceph_conf
-_rt_require_lib "libsoftokn3.so \
+req_inst=()
+_rt_require_lib req_inst "libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
 		   strace stat truncate touch cut chmod getfattr setfattr \
 		   getfacl setfacl killall sync dirname seq \
 		   $CEPH_FUSE_BIN \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--add-drivers "fuse" \

--- a/cut/ctdb_cephfs.sh
+++ b/cut/ctdb_cephfs.sh
@@ -25,7 +25,8 @@ _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 _rt_require_samba_ctdb
-_rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
+req_inst=()
+_rt_require_lib req_inst "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 _rt_mem_resources_set "1024M"
 
@@ -56,7 +57,7 @@ _rt_mem_resources_set "1024M"
 		   ${SAMBA_SRC}/bin/ctdb_recovery_helper \
 		   ${SAMBA_SRC}/bin/ctdb_takeover_helper \
 		   ${SAMBA_SRC}/bin/ctdb_mutex_ceph_rados_helper \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CTDB_EVENTS_DIR" "$CTDB_EVENTS_DIR" \
 	--include "${SAMBA_SRC}/ctdb/config/functions" \
 		  "/usr/local/samba/etc/ctdb/functions" \

--- a/cut/dropbear.sh
+++ b/cut/dropbear.sh
@@ -17,11 +17,12 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/dropbear.sh" "$@"
 _rt_require_networking
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs dropbear chmod \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT"

--- a/cut/fcoe_local.sh
+++ b/cut/fcoe_local.sh
@@ -16,12 +16,13 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fcoe_local.sh" "$@"
 _rt_require_networking
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 _rt_mem_resources_set "2048M"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs killall truncate dirname fipvlan basename \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--add-drivers "target_core_mod tcm_fc target_core_iblock \
 			target_core_file libfc fcoe scsi_debug" \
 	--modules "base" \

--- a/cut/fstests_btrfs.sh
+++ b/cut/fstests_btrfs.sh
@@ -8,9 +8,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/fstests.sh" \
 			"$RAPIDO_DIR/autorun/fstests_btrfs.sh" "$@"
 _rt_require_fstests
-_rt_require_btrfs_progs
-pam_paths=()
-_rt_require_pam_mods pam_paths "pam_rootok.so" "pam_limits.so"
+req_inst=()
+_rt_require_btrfs_progs req_inst
+_rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so"
 _rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
 	|| _fail "failed to calculate memory resources"
 # need enough memory for five zram devices
@@ -28,11 +28,10 @@ _rt_mem_resources_set "$((3072 + (zram_bytes * 5 / 1048576)))M"
 		   repquota setquota quotacheck quotaon pvremove vgremove \
 		   xfs_mkfile xfs_db xfs_io wipefs filefrag losetup \
 		   chgrp du fgrep pgrep tar rev kill duperemove \
-		   swapon swapoff xfs_freeze fsck ${pam_paths[*]} \
+		   swapon swapoff xfs_freeze fsck ${req_inst[*]} \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/*
-		   $BTRFS_PROGS_BINS" \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--add-drivers "zram lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
 		       loop scsi_debug dm-log-writes xxhash_generic ext4 \

--- a/cut/fstests_btrfs_zoned.sh
+++ b/cut/fstests_btrfs_zoned.sh
@@ -7,9 +7,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/fstests_btrfs_zoned.sh" "$@"
 _rt_require_fstests
-_rt_require_btrfs_progs
-pam_paths=()
-_rt_require_pam_mods pam_paths "pam_rootok.so" "pam_limits.so"
+req_inst=()
+_rt_require_btrfs_progs req_inst
+_rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so"
 # need enough memory for two 12G null_blk devices
 _rt_mem_resources_set "16384M"
 
@@ -26,10 +26,9 @@ _rt_mem_resources_set "16384M"
 		   xfs_mkfile xfs_db xfs_io wipefs filefrag losetup \
 		   chgrp du fgrep pgrep tar rev kill duperemove blkzone \
 		   swapon swapoff xfs_freeze fsck blktrace blkparse \
-		   ${pam_paths[*]} ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${req_inst[*]} ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/*
-		   $BTRFS_PROGS_BINS" \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--add-drivers "lzo lzo-rle dm-snapshot dm-flakey btrfs raid6_pq \
 		       loop scsi_debug dm-log-writes xxhash_generic null_blk" \

--- a/cut/fstests_exfat.sh
+++ b/cut/fstests_exfat.sh
@@ -8,9 +8,9 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/fstests.sh" \
 			"$RAPIDO_DIR/autorun/fstests_exfat.sh" "$@"
 _rt_require_fstests
-_rt_require_exfat_progs
-pam_paths=()
-_rt_require_pam_mods pam_paths "pam_rootok.so" "pam_limits.so"
+req_inst=()
+_rt_require_exfat_progs req_inst
+_rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so"
 _rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
 	|| _fail "failed to calculate memory resources"
 # 2x multiplier for one test and one scratch zram. +2G as buffer
@@ -28,11 +28,10 @@ _rt_mem_resources_set "$((2048 + (zram_bytes * 2 / 1048576)))M"
 		   repquota setquota quotacheck quotaon pvremove vgremove \
 		   xfs_mkfile xfs_db xfs_io wipefs filefrag losetup \
 		   chgrp du fgrep pgrep tar rev kill duperemove \
-		   swapon swapoff xfs_freeze fsck ${pam_paths[*]} \
+		   swapon swapoff xfs_freeze fsck ${req_inst[*]} \
 		   ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
-		   ${FSTESTS_SRC}/src/aio-dio-regress/* \
-		   $EXFAT_PROGS_BINS" \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
 	--add-drivers "zram lzo lzo-rle dm-flakey exfat \
 		       loop scsi_debug dm-log-writes virtio_blk" \

--- a/cut/lio_rbd.sh
+++ b/cut/lio_rbd.sh
@@ -14,11 +14,12 @@ _rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/lib/ceph.sh" \
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/lrbd.sh
+++ b/cut/lrbd.sh
@@ -19,7 +19,8 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/lrbd.sh" "$@"
 _rt_require_networking
 _rt_require_ceph
 _rt_require_conf_dir LRBD_SRC TARGETCLI_SRC RTSLIB_SRC CONFIGSHELL_SRC
-_rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
+req_inst=()
+_rt_require_lib req_inst "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libcrypto.so libexpat.so libudev.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 # assign more memory
@@ -42,7 +43,7 @@ rados_cython="${CEPH_SRC}"/build/lib/cython_modules/lib.3/rados.cpython-34m.so
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df \
 		   $py3_files env ldconfig \
 		   dbus-daemon /etc/dbus-1/system.conf $rbd_bin $rados_cython \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/nvme_local.sh
+++ b/cut/nvme_local.sh
@@ -16,11 +16,12 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_local.sh" "$@"
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--add-drivers "nvme-core nvme-fabrics nvme-loop nvmet zram lzo lzo-rle" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \

--- a/cut/nvme_rbd.sh
+++ b/cut/nvme_rbd.sh
@@ -14,11 +14,12 @@ _rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/lib/ceph.sh" \
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/nvme_rdma.sh
+++ b/cut/nvme_rdma.sh
@@ -17,11 +17,12 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/nvme_rdma.sh" "$@"
 _rt_require_networking
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs killall nvme rdma \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--add-drivers "nvme-core nvme-fabrics nvme-rdma nvmet nvmet-rdma \
 		       rdma_rxe zram lzo lzo-rle ib_core ib_uverbs rdma_ucm \
 		       crc32_generic" \

--- a/cut/nvme_tcp_rbd.sh
+++ b/cut/nvme_tcp_rbd.sh
@@ -14,11 +14,12 @@ _rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/lib/ceph.sh" \
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/qemu_rbd.sh
+++ b/cut/qemu_rbd.sh
@@ -10,7 +10,8 @@ trap "rm $qemu_args_file" 0 1 2 3 15
 
 _rt_require_dracut_args
 _rt_require_ceph
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 cat >"$qemu_args_file" <<EOF
 -drive format=rbd,file=rbd:${CEPH_RBD_POOL}/${CEPH_RBD_IMAGE}:conf=${CEPH_CONF},if=virtio,cache=none,format=raw
@@ -21,7 +22,7 @@ _rt_qemu_custom_args_set "$qemu_args_file"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs lsscsi \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \
 	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/rbd.sh
+++ b/cut/rbd.sh
@@ -14,11 +14,12 @@ _rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/lib/ceph.sh" \
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/cut/rbd_nbd.sh
+++ b/cut/rbd_nbd.sh
@@ -23,7 +23,8 @@ _rt_require_dracut_args "$vm_ceph_conf" "${RAPIDO_DIR}/autorun/rbd_nbd.sh" "$@"
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_lib "libsoftokn3.so libsqlite3.so \
+req_inst=()
+_rt_require_lib req_inst "libsoftokn3.so libsqlite3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 
 # only support recent (cmake) source based builds for now
@@ -33,7 +34,7 @@ rbd_nbd_bin="${CEPH_SRC}/build/bin/rbd-nbd"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs mkfs.btrfs sync dirname uuidgen sleep \
-		   $LIBS_INSTALL_LIST $rbd_nbd_bin" \
+		   ${req_inst[*]} $rbd_nbd_bin" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--add-drivers "nbd" \

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -16,8 +16,8 @@ _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
 req_inst=()
 _rt_require_samba_srv req_inst "vfs/ceph.so"
-_rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
-		 libfreeblpriv3.so"	# NSS_InitContext() fails without
+_rt_require_lib req_inst "libssl3.so libsmime3.so libstdc++.so.6 \
+		libsoftokn3.so libfreeblpriv3.so"
 # assign more memory
 _rt_mem_resources_set "1024M"
 
@@ -25,7 +25,7 @@ _rt_mem_resources_set "1024M"
 		   which touch cut chmod true false \
 		   getfattr setfattr chacl attr killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   ${req_inst[*]} $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_COMMON_LIB" "/usr/lib64/libceph-common.so.0" \
 	--include "$CEPHFS_LIB" "/usr/lib64/libcephfs.so.2" \
 	--include "$CEPH_RADOS_LIB" "/usr/lib64/librados.so.2" \

--- a/cut/samba_cephfs.sh
+++ b/cut/samba_cephfs.sh
@@ -14,7 +14,8 @@ _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lib/samba.sh" \
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config $vm_ceph_conf
-_rt_require_samba_srv "vfs/ceph.so"
+req_inst=()
+_rt_require_samba_srv req_inst "vfs/ceph.so"
 _rt_require_lib "libssl3.so libsmime3.so libstdc++.so.6 libsoftokn3.so \
 		 libfreeblpriv3.so"	# NSS_InitContext() fails without
 # assign more memory
@@ -24,7 +25,7 @@ _rt_mem_resources_set "1024M"
 		   which touch cut chmod true false \
 		   getfattr setfattr chacl attr killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   $SAMBA_SRV_BINS $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]} $LIBS_INSTALL_LIST" \
 	--include "$CEPH_COMMON_LIB" "/usr/lib64/libceph-common.so.0" \
 	--include "$CEPHFS_LIB" "/usr/lib64/libcephfs.so.2" \
 	--include "$CEPH_RADOS_LIB" "/usr/lib64/librados.so.2" \

--- a/cut/samba_kernel_cephfs.sh
+++ b/cut/samba_kernel_cephfs.sh
@@ -14,7 +14,8 @@ _rt_require_dracut_args "$vm_ceph_conf" "$RAPIDO_DIR/autorun/lib/samba.sh" \
 _rt_require_networking
 _rt_require_ceph
 _rt_write_ceph_config "$vm_ceph_conf"
-_rt_require_samba_srv
+req_inst=()
+_rt_require_samba_srv req_inst
 # assign more memory
 _rt_mem_resources_set "1024M"
 
@@ -22,7 +23,7 @@ _rt_mem_resources_set "1024M"
 		   strace stat which touch cut chmod true false \
 		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   $SAMBA_SRV_BINS" \
+		   ${req_inst[*]}" \
 	--add-drivers "ceph libceph" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \

--- a/cut/samba_local.sh
+++ b/cut/samba_local.sh
@@ -8,7 +8,8 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/samba.sh" \
 			"$RAPIDO_DIR/autorun/samba_local.sh" "$@"
 _rt_require_networking
-_rt_require_samba_srv "vfs/btrfs.so"
+req_inst=()
+_rt_require_samba_srv req_inst "vfs/btrfs.so"
 # assign more memory
 _rt_mem_resources_set "1024M"
 
@@ -17,7 +18,7 @@ _rt_mem_resources_set "1024M"
 		   stat which touch cut chmod true false \
 		   getfattr setfattr getfacl setfacl killall sync \
 		   id sort uniq date expr tac diff head dirname seq \
-		   $SAMBA_SRV_BINS" \
+		   ${req_inst[*]}" \
 	--add-drivers "zram lzo lzo-rle xfs btrfs" \
 	--modules "base" \
 	"${DRACUT_RAPIDO_ARGS[@]}" \

--- a/cut/tcmu_rbd_loop.sh
+++ b/cut/tcmu_rbd_loop.sh
@@ -20,7 +20,8 @@ _rt_require_networking
 _rt_require_conf_dir TCMU_RUNNER_SRC CEPH_SRC
 _rt_require_ceph
 # NSS_InitContext() fails without the following...
-_rt_require_lib "libsoftokn3.so libfreeblpriv3.so"
+req_inst=()
+_rt_require_lib req_inst "libsoftokn3.so libfreeblpriv3.so"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs.xfs mkfs.btrfs sync dirname uuidgen \
@@ -29,7 +30,7 @@ _rt_require_lib "libsoftokn3.so libfreeblpriv3.so"
 		   ${CEPH_SRC}/build/lib/librados.so \
 		   ${TCMU_RUNNER_SRC}/tcmu-runner \
 		   ${TCMU_RUNNER_SRC}/handler_rbd.so \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--add-drivers "target_core_mod target_core_user tcm_loop" \

--- a/cut/usb_rbd.sh
+++ b/cut/usb_rbd.sh
@@ -18,7 +18,8 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/usb_rbd.sh" "$@"
 _rt_require_networking
 _rt_require_ceph
-_rt_require_lib "libkeyutils.so.1"
+req_inst=()
+_rt_require_lib req_inst "libkeyutils.so.1"
 
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   eject strace mkfs.vfat mountpoint \
@@ -26,7 +27,7 @@ _rt_require_lib "libkeyutils.so.1"
 		   /usr/lib/udev/rules.d/10-dm.rules \
 		   /usr/lib/udev/rules.d/13-dm-disk.rules \
 		   /usr/lib/udev/rules.d/95-dm-notify.rules \
-		   $LIBS_INSTALL_LIST" \
+		   ${req_inst[*]}" \
 	--include "$CEPH_CONF" "/etc/ceph/ceph.conf" \
 	--include "$CEPH_KEYRING" "/etc/ceph/keyring" \
 	--include "$RBD_NAMER_BIN" "/usr/bin/ceph-rbdnamer" \

--- a/runtime.vars
+++ b/runtime.vars
@@ -174,6 +174,7 @@ _rt_require_btrfs_progs() {
 }
 
 _rt_require_exfat_progs() {
+	declare -n req_inst_ref="$1" || _fail "output ref parameter required"
 	# sbin paths search paths may be needed for non-root
 	local p="${PATH}:/sbin:/usr/sbin"
 
@@ -183,10 +184,7 @@ _rt_require_exfat_progs() {
 	fi
 
 	# dump.exfat not present in older versions and isn't needed for fstests
-	EXFAT_PROGS_BINS="$(PATH=$p type -P \
-				mkfs.exfat \
-				fsck.exfat \
-				tune.exfat)" \
+	req_inst_ref+=( $(PATH=$p type -P mkfs.exfat fsck.exfat tune.exfat) ) \
 		|| _fail "missing exfat_progs binaries"
 }
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -158,6 +158,7 @@ _rt_require_fstests() {
 }
 
 _rt_require_btrfs_progs() {
+	declare -n req_inst_ref="$1" || _fail "output ref parameter required"
 	# sbin paths search paths may be needed for non-root
 	local p="${PATH}:/sbin:/usr/sbin"
 
@@ -165,11 +166,11 @@ _rt_require_btrfs_progs() {
 		p="${BTRFS_PROGS_SRC}"
 	fi
 
-	BTRFS_PROGS_BINS="$(PATH=$p type -P \
+	req_inst_ref+=( $(PATH=$p type -P \
 				mkfs.btrfs \
 				btrfs \
 				btrfs-convert \
-				btrfstune)" \
+				btrfstune) ) \
 		|| _fail "missing btrfs-progs binaries"
 }
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -190,6 +190,7 @@ _rt_require_exfat_progs() {
 }
 
 _rt_require_samba_srv() {
+	declare -n req_inst_ref="$1" || _fail "output ref parameter required"
 	local p="${PATH}:/sbin:/usr/sbin"
 	local mods_p="/usr/lib64/samba"
 
@@ -198,17 +199,17 @@ _rt_require_samba_srv() {
 		mods_p="${SAMBA_SRC}/bin/modules"
 	fi
 
-	# any parameters are treated as extra modules
-	local mods=("${mods_p}/pdb/tdbsam.so")
+	# any subsequent parameters are treated as extra modules
+	shift
+	req_inst_ref+=("${mods_p}/pdb/tdbsam.so")
 	while (( $# > 0 )) ; do
 		[ -f "${mods_p}/${1}" ] || _fatal "Samba module $1 missing"
-		mods+=("${mods_p}/${1}")
+		req_inst_ref+=("${mods_p}/${1}")
 		shift
 	done
 
-	SAMBA_SRV_BINS="$(PATH=$p type -P smbpasswd smbstatus smbd)" \
+	req_inst_ref+=( $(PATH=$p type -P smbpasswd smbstatus smbd) ) \
 		|| _fail "missing samba server binaries"
-	SAMBA_SRV_BINS="$SAMBA_SRV_BINS ${mods[*]}"
 }
 
 _rt_require_blktests() {

--- a/runtime.vars
+++ b/runtime.vars
@@ -363,12 +363,14 @@ _rt_require_qemu_args() {
 }
 
 _rt_require_lib() {
+	declare -n req_inst_ref="$1" || _fail "output ref parameter required"
 	local libname
+	shift
 	for libname in $1; do
 		local library=`/sbin/ldconfig -p \
 			| awk 'index($1, "'${libname}'") == 1 {print $NF}'`
 		[ -n "$library" ] || _fail "can't find library '$libname'"
-		LIBS_INSTALL_LIST="$LIBS_INSTALL_LIST $library"
+		req_inst_ref+=("$library")
 	done
 }
 


### PR DESCRIPTION
Use variable references for `_rt_req_X` function return values instead of per-function magic global variables, as outlined in https://github.com/rapido-linux/rapido/issues/205 .

```
The following changes since commit 15c90a411fa4bc62c9a2a58f6f4e2c05a2d629e5:

  Merge remote-tracking branch 'ddiss/keyctl_and_fstests_su' (2023-03-13 20:12:11 +0100)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git drop_some_globals

for you to fetch changes up to 5d33cd5c7de69b2d9b87c5d9f5ef27d0f2518ca3:

  cut: drop LIBS_INSTALL_LIST global (2023-03-18 00:33:49 +0100)

----------------------------------------------------------------
David Disseldorp (4):
      cut/fstests_exfat: drop EXFAT_PROGS_BINS global
      cut/fstests_btrfs: drop BTRFS_PROGS_BINS global
      cut/samba: drop SAMBA_SRV_BINS global
      cut: drop LIBS_INSTALL_LIST global

 cut/cephfs_fuse.sh         |  5 +++--
 cut/ctdb_cephfs.sh         |  5 +++--
 cut/dropbear.sh            |  5 +++--
 cut/fcoe_local.sh          |  5 +++--
 cut/fstests_btrfs.sh       | 11 +++++------
 cut/fstests_btrfs_zoned.sh | 11 +++++------
 cut/fstests_exfat.sh       | 11 +++++------
 cut/lio_rbd.sh             |  5 +++--
 cut/lrbd.sh                |  5 +++--
 cut/nvme_local.sh          |  5 +++--
 cut/nvme_rbd.sh            |  5 +++--
 cut/nvme_rdma.sh           |  5 +++--
 cut/nvme_tcp_rbd.sh        |  5 +++--
 cut/qemu_rbd.sh            |  5 +++--
 cut/rbd.sh                 |  5 +++--
 cut/rbd_nbd.sh             |  5 +++--
 cut/samba_cephfs.sh        |  9 +++++----
 cut/samba_kernel_cephfs.sh |  5 +++--
 cut/samba_local.sh         |  5 +++--
 cut/tcmu_rbd_loop.sh       |  5 +++--
 cut/usb_rbd.sh             |  5 +++--
 runtime.vars               | 26 ++++++++++++++------------
 22 files changed, 85 insertions(+), 68 deletions(-)
```