### PR TITLE
cut/samba: assign memory based on FSTESTS_ZRAM_SIZE

### DIFF
--- a/cut/samba_btrfs.sh
+++ b/cut/samba_btrfs.sh
@@ -10,8 +10,9 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/samba.sh" \
 _rt_require_networking
 req_inst=()
 _rt_require_samba_srv req_inst "vfs/btrfs.so"
-# assign more memory
-_rt_mem_resources_set "1024M"
+_rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
+	|| _fail "failed to calculate memory resources"
+_rt_mem_resources_set "$((1024 + (zram_bytes / 1048576)))M"
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.btrfs awk dirname \

--- a/cut/samba_xfs.sh
+++ b/cut/samba_xfs.sh
@@ -10,7 +10,9 @@ _rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/samba.sh" \
 _rt_require_networking
 req_inst=()
 _rt_require_samba_srv req_inst
-_rt_mem_resources_set "1024M"
+_rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
+	|| _fail "failed to calculate memory resources"
+_rt_mem_resources_set "$((1024 + (zram_bytes / 1048576)))M"
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs awk dirname \


### PR DESCRIPTION
As of dad4527, the local filesystem Samba runners provision one zram device of size FSTESTS_ZRAM_SIZE (or 1G if unset). Assign VM memory taking this into account, with 1G extra assigned for system memory.

Fixes: dad4527 ("samba-local: configure Btrfs backed shares")