### PR TITLE
minor: autorun/udev and rapido usage cleanups

### DIFF
--- a/autorun/fcoe_local.sh
+++ b/autorun/fcoe_local.sh
@@ -16,9 +16,7 @@ _vm_ar_env_check || exit 1
 
 set -x
 
-#### start udevd
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 modprobe configfs
 _vm_ar_configfs_mount

--- a/autorun/lib/ceph.sh
+++ b/autorun/lib/ceph.sh
@@ -10,8 +10,7 @@ _ceph_rbd_map() {
 	[ -z "$CEPH_USER_KEY" ] && _fatal "CEPH_USER_KEY not configured"
 
 	# start udevd, otherwise rbd hangs in wait_for_udev_add()
-	ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-		|| /usr/lib/systemd/systemd-udevd --daemon
+	/usr/lib/systemd/systemd-udevd --daemon
 
 	local add_path
 	for add_path in /sys/bus/rbd/add_single_major /sys/bus/rbd/add; do

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -12,15 +12,14 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
+# TODO only consider bdevs with expected serial string, like fstests runners
 export_blockdevs="/dev/vda /dev/vdb"
 
 _vm_ar_env_check || exit 1
 
 set -x
 
-# start udevd
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 udevadm settle || _fatal
 
 _vm_ar_configfs_mount

--- a/autorun/lio_local_alua_lba.sh
+++ b/autorun/lio_local_alua_lba.sh
@@ -20,8 +20,7 @@ lio_cfgfs="/sys/kernel/config/target/"
 lu_name="lu_file"
 dev_size="$(( 1024 * 1024 * 1024 ))"
 
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 _vm_ar_configfs_mount
 

--- a/autorun/nvme_local.sh
+++ b/autorun/nvme_local.sh
@@ -31,9 +31,7 @@ function _zram_hot_add() {
 
 set -x
 
-#### start udevd
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 modprobe configfs
 _vm_ar_configfs_mount

--- a/autorun/nvme_rdma.sh
+++ b/autorun/nvme_rdma.sh
@@ -31,9 +31,7 @@ function _zram_hot_add() {
 
 set -x
 
-#### start udevd
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 modprobe configfs
 _vm_ar_configfs_mount

--- a/autorun/nvme_tcp_initiator.sh
+++ b/autorun/nvme_tcp_initiator.sh
@@ -16,9 +16,7 @@ _vm_ar_env_check || exit 1
 
 set -x
 
-#### start udevd
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 modprobe configfs
 _vm_ar_configfs_mount

--- a/autorun/rbd_nbd.sh
+++ b/autorun/rbd_nbd.sh
@@ -16,8 +16,7 @@ _vm_ar_env_check || exit 1
 
 set -x
 
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 modprobe nbd nbds_max=1
 

--- a/autorun/tcmu_file_iscsi.sh
+++ b/autorun/tcmu_file_iscsi.sh
@@ -21,8 +21,7 @@ lu_name="tcmu_file"
 tcmu_dev_conf="file/${lu_name}.img"
 tcmu_dev_size="$(( 1024 * 1024 * 1024 ))"
 
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 _vm_ar_configfs_mount
 

--- a/autorun/tcmu_rbd_loop.sh
+++ b/autorun/tcmu_rbd_loop.sh
@@ -27,8 +27,7 @@ lu_name="tcmu_rbd_lu"
 tcmu_dev_conf="rbd/${CEPH_RBD_POOL}/${CEPH_RBD_IMAGE}"
 tcmu_dev_size="$(( $CEPH_RBD_IMAGE_MB * 1024 * 1024 ))"
 
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+/usr/lib/systemd/systemd-udevd --daemon
 
 _vm_ar_configfs_mount
 

--- a/autorun/usb_rbd.sh
+++ b/autorun/usb_rbd.sh
@@ -16,9 +16,8 @@ _vm_ar_env_check || exit 1
 
 set -x
 
-#### ddiss - start udevd, so that the rbdnamer hook is invoked
-ps -eo args | grep -v grep | grep /usr/lib/systemd/systemd-udevd \
-	|| /usr/lib/systemd/systemd-udevd --daemon
+#### start udevd, so that the rbdnamer hook is invoked
+/usr/lib/systemd/systemd-udevd --daemon
 
 # ensure that conf FS is exposed before RBD mapping
 touch /usr/lib/rbd-usb-run-conf.flag

--- a/rapido
+++ b/rapido
@@ -99,8 +99,12 @@ rapido_cut()
 	cut_script="cut/${testname//-/_}.sh"
 
 	if [[ ! -x $cut_script ]]; then
-		echo "Test ${testname} not found, please use one of:"
-		rapido_list
+		if [[ -f $cut_script ]]; then
+			echo "$cut_script lacking execute permission."
+		else
+			echo "$cut_script not found, please use one of:"
+			rapido_list
+		fi
 		popd > /dev/null
 		exit
 	fi


### PR DESCRIPTION
```
The following changes since commit 495421853590ed014fc2889dfcfaa632ce3da01f:

  cut/samba: assign memory based on FSTESTS_ZRAM_SIZE (2023-04-25 12:06:33 +0200)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git udevd_start

for you to fetch changes up to 6ca506ef2a720a7fb0f9454f64cb3b6d244baf5e:

  rapido: improve usage for missing exec mode (2023-06-20 18:11:37 +0200)

----------------------------------------------------------------
David Disseldorp (2):
      autorun: start udev unconditionally
      rapido: improve usage for missing exec mode

 autorun/fcoe_local.sh         | 4 +---
 autorun/lib/ceph.sh           | 3 +--
 autorun/lio_local.sh          | 5 ++---
 autorun/lio_local_alua_lba.sh | 3 +--
 autorun/nvme_local.sh         | 4 +---
 autorun/nvme_rdma.sh          | 4 +---
 autorun/nvme_tcp_initiator.sh | 4 +---
 autorun/rbd_nbd.sh            | 3 +--
 autorun/tcmu_file_iscsi.sh    | 3 +--
 autorun/tcmu_rbd_loop.sh      | 3 +--
 autorun/usb_rbd.sh            | 5 ++---
 rapido                        | 8 ++++++--
 12 files changed, 19 insertions(+), 30 deletions(-)
```