### PR TITLE
kselftests: Add new cut for kernel selftests

### DIFF
--- a/autorun/kselftests.sh
+++ b/autorun/kselftests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2018-2021, all rights reserved.
+
+# autorun scripts are run once the Rapido scratch VM has booted. The scripts
+# are sourced by vm_autorun.env and have access to rapido.conf variables.
+
+# protect against running (harmful) scripts outside of Rapido VMs
+_vm_ar_env_check || exit 1
+
+# echo shell commands as they are executed
+set -x
+
+# enable dynamic debug for any DYN_DEBUG_MODULES or DYN_DEBUG_FILES specified in
+# rapido.conf. All kernel modules *should* be loaded before calling
+_vm_ar_dyn_debug_enable
+
+set +x
+
+cd "$KSELFTESTS_DIR"
+
+cat <<EOF
+To run a test:
+  ./run_kselftest.sh ...
+
+E.g. to run all tests on boot:
+  ./rapido cut -x './run_kselftest.sh ...'
+EOF

--- a/cut/kselftests.sh
+++ b/cut/kselftests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2018-2021, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+# The job of Rapido cut scripts is to generate a VM image. This is done using
+# Dracut with a number of parameters...
+
+# Call _rt_require_dracut_args() providing script paths that will be included
+# and run on VM boot. It exports variables used in the dracut invocation below.
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/kselftests.sh" "$@"
+
+# _rt_require_networking() flags that VMs using this image should have a network
+# adapter. Binaries and configuration required for networking are appended to
+# DRACUT_RAPIDO_ARGS.
+#_rt_require_networking
+
+# VMs are booted with 2 vCPUs and 512M RAM by default.
+# cpuset test requires >= 8 CPUs
+_rt_cpu_resources_set 8
+
+# --install provides a list of binaries that should be included in the VM image.
+# Dracut will resolve shared object dependencies and add them automatically.
+
+# --include copies a specific file or directory to the given image destination.
+_rt_require_conf_dir KSELFTESTS_DIR
+
+# --add-drivers provides a list of kernel modules, which will be obtained from
+# the rapido.conf KERNEL_INSTALL_MOD_PATH
+
+# --modules provides a list of *Dracut* modules. See Dracut documentation for
+# details
+"$DRACUT" \
+	--install "awk basename cut date dirname echo expr fmt grep head id
+	           lscpu ps realpath rmdir sort uniq wc" \
+	--include "$KSELFTESTS_DIR" "$KSELFTESTS_DIR" \
+	--modules "base dracut-systemd" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -331,3 +331,10 @@ LTP_DIR="/opt/ltp"
 #e.g. NFS_MOUNT_OPTS="nfsvers=3"
 #NFS_MOUNT_OPTS=""
 ###############################################
+
+########## cut/kselftests.sh ##########
+# Path to the installation of kselftests (must be built and installed in
+# advance, e.g. "make O=$KERNEL_SRC TARGETS=... kselftest-install")
+# Default value expectes out of source kernel build in KERNEL_SRC (sic)
+KSELFTESTS_DIR="${KERNEL_SRC}/kselftest/kselftest_install"
+#######################################


### PR DESCRIPTION
Initial version of kselftest inclusion in the test image, the implementation is tested only with 'cgroup' subset of kselftests.