### PR TITLE
tools/br_tap_setup.sh: fix cleanup of rapido_tapdevs.X files

### DIFF
--- a/tools/br_tap_setup.sh
+++ b/tools/br_tap_setup.sh
@@ -88,8 +88,8 @@ tmpf=$(mktemp "rapido_tapdevs.XXXXXXX")
 [[ -f $tmpf ]] || _fail "mktemp failed"
 
 # cleanup on premature exit by executing whatever has been prepended to @unwind
-unwind="rm \"$tmpf\""
-trap "eval \$unwind" 0 1 2 3 15
+unwind=""
+trap "eval \$unwind; rm \"$tmpf\"" 0 1 2 3 15
 
 _tap_manifest_gen "$tmpf" "$br_name"
 


### PR DESCRIPTION
$unwind is cleared prior to successful exit, so shouldn't be used for tempfile cleanup.

Will merge this later today if no objections.