### PR TITLE
Quick start

### DIFF
--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -45,17 +45,16 @@ TAP_USER=""
 # e.g. VIRTFS_SHARE_PATH="/tmp/rapido/"
 #VIRTFS_SHARE_PATH=""
 
-# extra qemu-kvm arguments to append for both VMs:
-# "-nographic" sees the emulated serial port redirected to the invoking console.
-# "-display none -daemonize" can be used to run VMs in the background, without
-# redirection.
-# "-device virtio-rng-pci" sees the guest make use of /dev/random on the
-# hypervisor for random number generation.
+# QEMU_EXTRA_ARGS are used as trailing QEMU parameters. Rapido defaults are:
+# "-nographic": run as a command line application with a VM serial port
+#               redirected to the console. If you wish to run VMs as background
+#               processes, replace this with "-display none -daemonize".
+# "-device virtio-rng-pci": add a RNG device backed by /dev/random on the host.
 #
 # e.g. QEMU_EXTRA_ARGS="-nographic -drive file=/dev/sdz,if=virtio,cache=none,format=raw,index=0"
 # e.g. QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci -gdb tcp:127.0.0.1:1234"
 # e.g. QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci -drive id=test,file=/tmp/fstests-test.qcow2,if=none,cache=none -device virtio-blk-pci,drive=test,bus=pci.0,serial=TEST_DEV -drive id=scratch,file=/tmp/fstests-scratch.qcow2,if=none,cache=none -device virtio-blk-pci,drive=scratch,bus=pci.0,serial=SCRATCH_DEV"
-QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
+#QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
 
 # extra kernel boot parameters, passed via QEMU -append
 # e.g. QEMU_EXTRA_KERNEL_PARAMS="loglevel=0"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,16 @@
 Rapido helps you quickly test Linux kernel changes.
 
-The scripts that make up Rapido are in themselves quite brainless. Most
-of the heavy lifting is instead performed by:
+## Quick Start
+
+```shell
+# install dracut and qemu
+git clone https://github.com/rapido-linux/rapido.git && cd rapido
+./rapido cut simple-example # boot a throwaway VM using the host kernel
+```
+
+## Setup
+
+Clone this repository and install the following dependencies:
 
 * [Dracut](https://dracut.wiki.kernel.org):
   * Generates a VM image, with kernel-modules and minimal user-space
@@ -13,15 +22,14 @@ of the heavy lifting is instead performed by:
 * [iproute2](https://wiki.linuxfoundation.org/networking/iproute2):
   * Configures Bridge and TAP devices on the host (optional)
 
-Dependencies are obtained from the local system; no magic images or
-internet downloads are necessary.
+Rapido obtains all dependencies from the local system; no magic images
+or internet downloads are necessary. Individual cut scripts (e.g.
+`cut/fstests_btrfs.sh`) may require extra dependencies.
 
+Rapido is primarily configured via `rapido.conf`. To boot a custom Linux
+kernel, copy [rapido.conf.example](rapido.conf.example) and set the
+`KERNEL_SRC` parameter to the path of your compiled kernel source.
 
-## Setup
-
-Once the dependencies listed above have been installed, Rapido can be
-configured via [rapido.conf](rapido.conf.example). At a minimum, the
-Linux kernel source parameters should be defined.
 
 ### Network Configuration
 

--- a/runtime.vars
+++ b/runtime.vars
@@ -23,10 +23,18 @@ QEMU_PID_DIR="${RAPIDO_DIR}/initrds"
 # default VM network config path, also used for tap provisioning
 VM_NET_CONF="${RAPIDO_DIR}/net-conf"
 
-# process user defined configuration
-RAPIDO_CONF="${RAPIDO_CONF:-${RAPIDO_DIR}/rapido.conf}"
-. "$RAPIDO_CONF" \
-	|| _fail "$RAPIDO_CONF processing failed - see rapido.conf.example"
+# QEMU defaults: CLI with console redirection. Provide VMs with an RNG device.
+QEMU_EXTRA_ARGS="-nographic -device virtio-rng-pci"
+
+if [[ -n $RAPIDO_CONF ]]; then
+	# explicit user-provided conf path; fail if missing.
+	. "$RAPIDO_CONF" || _fail "$RAPIDO_CONF missing"
+else
+	# use default rapido.conf path; continue if missing.
+	RAPIDO_CONF="${RAPIDO_DIR}/rapido.conf"
+	. "$RAPIDO_CONF" 2> /dev/null \
+	  || _warn "$(realpath $RAPIDO_CONF) missing - see rapido.conf.example"
+fi
 
 _rt_ceph_src_globals_set() {
 	[ -d "$CEPH_SRC" ] || _fail "$CEPH_SRC is not a directory"
@@ -241,7 +249,9 @@ _rt_require_dracut_args() {
 	local env_src="$RAPIDO_DIR/vm_autorun.env"
 	local rinit_src="$RAPIDO_DIR/autorun/00-rapido-init.sh"
 	local rinit_dst="/lib/dracut/hooks/cmdline/00-rapido-init.sh"
-	DRACUT_RAPIDO_ARGS+=(--include "$RAPIDO_CONF" /rapido.conf \
+	local conf_src="$RAPIDO_CONF"
+	[[ -f $RAPIDO_CONF ]] || conf_src="${RAPIDO_DIR}/dracut.conf.d/.empty"
+	DRACUT_RAPIDO_ARGS+=(--include "$conf_src" /rapido.conf \
 			     --include "$env_src" /etc/profile \
 			     --include "$rinit_src" "$rinit_dst")
 


### PR DESCRIPTION
```
The following changes since commit 9c39d5aefbd9249d0f5965f20fbb58fafa47cb5c:

  tools/br_tap_setup.sh: fix cleanup of rapido_tapdevs.X files (2023-07-27 14:57:53 +0200)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git quick_start

for you to fetch changes up to 1903ee57dabd8e0dcf0d4a35cdddcc3385643c4a:

  readme: add Quick Start section and rework Setup (2023-08-10 19:40:00 +0200)

----------------------------------------------------------------
David Disseldorp (2):
      runtime: don't fail if rapido.conf is missing
      readme: add Quick Start section and rework Setup

 rapido.conf.example | 13 ++++++-------
 readme.md           | 26 +++++++++++++++++---------
 runtime.vars        |  9 +++++++--
 3 files changed, 30 insertions(+), 18 deletions(-)
```