### PR TITLE
runtime: fix _rt_write_ceph_config parsing

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -114,17 +114,17 @@ _rt_write_ceph_config() {
 	[ -n "$CEPH_USER" ] || _fail "CEPH_USER not configured"
 
 	# get key
-	local value=($(_ceph_get_key))
+	local value="$(_ceph_get_key)"
 	[ -n "$value" ] || _fail "Can't find key for client.$CEPH_USER"
 	echo "CEPH_USER_KEY=$value" >> $vm_ceph_conf
 
 	# get monitor address
 	value=""
 	if [ -n "$CEPH_MON_NAME" ]; then
-		value=($(_ceph_get_conf "mon.${CEPH_MON_NAME}" "mon addr"))
+		value="$(_ceph_get_conf "mon.${CEPH_MON_NAME}" "mon addr")"
 	fi
 	if [ -z "$value" ]; then
-		value=($(_ceph_get_conf "global" "mon host"))
+		value="$(_ceph_get_conf "global" "mon host")"
 	fi
 	[ -n "$value" ] || _fail "Can't find mon address"
 	# get both msgr v1 and v2 monitor addresses
@@ -136,9 +136,9 @@ _rt_write_ceph_config() {
 	[ "$addrv1" != "$addrv2" ] && echo "CEPH_MON_ADDRESS_V2=$addrv2" >> $vm_ceph_conf
 
 	# get mds_root_ino_{uid,gid}
-	value=($(_ceph_get_conf "mds" "mds root ino uid"))
+	value="$(_ceph_get_conf "mds" "mds root ino uid")"
 	[ -n "$value" ] && echo "CEPH_ROOT_INO_UID=$value" >> $vm_ceph_conf
-	value=($(_ceph_get_conf "mds" "mds root ino gid"))
+	value="$(_ceph_get_conf "mds" "mds root ino gid")"
 	[ -n "$value" ] && echo "CEPH_ROOT_INO_GID=$value" >> $vm_ceph_conf
 }
 


### PR DESCRIPTION
The value=(...) bash array syntax doesn't match $value usage, and breaks parsing of, e.g.:
  [global]
    mon host =  [v2:192.168.159.1:40716,v1:192.168.159.1:40717]