### PR TITLE
autorun/ltp: Export `KCONFIG_PATH`

### DIFF
--- a/autorun/ltp.sh
+++ b/autorun/ltp.sh
@@ -17,6 +17,7 @@ for ug in nobody bin daemon; do
 done
 
 export CREATE_ENTRIES=0
+export KCONFIG_PATH=/.config
 export LTPROOT="$LTP_DIR"
 export PATH="$LTP_DIR:$LTP_DIR/bin:$LTP_DIR/testcases/bin:$PATH"
 


### PR DESCRIPTION
Kernel config in rapido is in nonstandard path, point the correct location via `KCONFIG_PATH` environment variable so that user does not have to do it manually.

Also move `KCONFIG_PATH` to `rapido.conf.example`, so that it does not have to be defined on both `autorun/ltp.sh` and `cut/ltp.sh`.

Fixes: db9be25 ("cut/ltp: Install kernel config when local kernel booted")