### PR TITLE
Distribution packaging changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,16 @@ install: all
 		dracut.conf.d/.empty dracut.conf.d/01-rapido-dracut.conf
 	install -t $(DESTDIR)$(pkglibdir) \
 		rapido runtime.vars vm.sh vm_autorun.env
-	mkdir -p $(DESTDIR)$(bindir)
+	mkdir -p $(DESTDIR)$(bindir) $(DESTDIR)$(sysconfdir)/rapido
 	# symlink ensures that RAPIDO_DIR can be found via realpath
 	ln -s $(pkglibdir)/rapido $(DESTDIR)$(bindir)/
 	install -D tools/bash_completion \
 		$(DESTDIR)$(sysconfdir)/bash_completion.d/rapido
+	# use etc for configuration, and PWD for all (throwaway) VM image state
+	sed -e 's/^#VM_NET_CONF=.*/VM_NET_CONF="\/etc\/rapido\/net-conf"/' \
+	    -e 's/^#QEMU_PID_DIR=.*/QEMU_PID_DIR="$$PWD"/' \
+	    -e 's/^#DRACUT_OUT=.*/DRACUT_OUT="$${PWD}\/rapido.cpio"/' \
+	    rapido.conf.example > $(DESTDIR)$(sysconfdir)/rapido/rapido.conf
 
 
 .DEFAULT_GOAL = all

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2023, all rights reserved.
+
+#TODO libexec?
+bindir ?= /usr/bin
+libdir ?= /usr/lib
+pkglibdir ?= ${libdir}/rapido
+sysconfdir ?= /etc
+
+.PHONY: install clean test all
+
+all:
+	$(info No compilation required.)
+
+clean:
+	$(info Nothing to clean up.)
+
+test:
+	selftest/selftest.sh
+
+install: all
+	install -D -t $(DESTDIR)$(pkglibdir)/cut cut/*.sh
+	install -D -t $(DESTDIR)$(pkglibdir)/autorun/lib autorun/lib/*.sh
+	install -t $(DESTDIR)$(pkglibdir)/autorun autorun/*.sh
+	install -D -t $(DESTDIR)$(pkglibdir)/tools tools/*.sh
+	install -m 644 -D -t $(DESTDIR)$(pkglibdir)/dracut.conf.d \
+		dracut.conf.d/.empty dracut.conf.d/01-rapido-dracut.conf
+	install -t $(DESTDIR)$(pkglibdir) \
+		rapido runtime.vars vm.sh vm_autorun.env
+	mkdir -p $(DESTDIR)$(bindir)
+	# symlink ensures that RAPIDO_DIR can be found via realpath
+	ln -s $(pkglibdir)/rapido $(DESTDIR)$(bindir)/
+	install -D tools/bash_completion \
+		$(DESTDIR)$(sysconfdir)/bash_completion.d/rapido
+
+
+.DEFAULT_GOAL = all

--- a/rapido
+++ b/rapido
@@ -1,18 +1,9 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LINUX GmbH 2018, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2018, all rights reserved.
 
-RAPIDO_DIR="$(realpath -e ${0%/*})"
+RAPIDO_DIR="$(realpath -e $BASH_SOURCE)"
+RAPIDO_DIR="${RAPIDO_DIR%/*}"
 
 declare -A short_help
 

--- a/rapido
+++ b/rapido
@@ -86,20 +86,17 @@ rapido_cut()
 		exit 1
 	fi
 
-	pushd "$RAPIDO_DIR" > /dev/null
-	cut_script="cut/${testname//-/_}.sh"
+	cut_script="${RAPIDO_DIR}/cut/${testname//-/_}.sh"
 
 	if [[ ! -x $cut_script ]]; then
 		[[ -f $cut_script ]] \
 		  && echo "$cut_script lacks execute permission." \
 		  || echo "$testname not found. See \"rapido list\"."
-		popd > /dev/null
 		exit
 	fi
 
-	./$cut_script "${post_autorun_files[@]}"
+	"$cut_script" "${post_autorun_files[@]}"
 	local cut_status=$?
-	popd > /dev/null
 	[ $cut_status -ne 0 ] && exit $cut_status
 	[ -n "$boot_img" ] || exit 0
 	"${RAPIDO_DIR}/vm.sh"

--- a/runtime.vars
+++ b/runtime.vars
@@ -30,8 +30,12 @@ if [[ -n $RAPIDO_CONF ]]; then
 	# explicit user-provided conf path; fail if missing.
 	. "$RAPIDO_CONF" || _fail "$RAPIDO_CONF missing"
 else
-	# use default rapido.conf path; continue if missing.
-	RAPIDO_CONF="${RAPIDO_DIR}/rapido.conf"
+	# default conf path; continue if missing. etc path is for distributions
+	if [ -f "/etc/rapido/rapido.conf" ]; then
+		RAPIDO_CONF="/etc/rapido/rapido.conf"
+	else
+		RAPIDO_CONF="${RAPIDO_DIR}/rapido.conf"
+	fi
 	. "$RAPIDO_CONF" 2> /dev/null \
 	  || _warn "$(realpath $RAPIDO_CONF) missing - see rapido.conf.example"
 fi

--- a/tools/bash_completion
+++ b/tools/bash_completion
@@ -14,13 +14,13 @@ __rapido()
 {
 	local bin cut_dir cur rcmd max_off seen_boot
 	local -a comps
-	bin="$1"
+	bin="$(realpath -e $1)"
 
 	# we only want to complete the rapido script, not dirs, etc.
 	[ -f "$bin" ] || return 0
 	[ -x "$bin" ] || return 0
 
-	cut_dir="$(dirname $bin)/cut"
+	cut_dir="${bin%/*}/cut"
 	[ -d "${cut_dir}" ] || return 0
 
 	COMPREPLY=()

--- a/tools/bash_completion
+++ b/tools/bash_completion
@@ -13,14 +13,19 @@ __rapido()
 {
 	local bin cut_dir cur rcmd max_off seen_boot
 	local -a comps
-	bin="$(realpath -e $1)"
 
-	# we only want to complete the rapido script, not dirs, etc.
-	[ -f "$bin" ] || return 0
-	[ -x "$bin" ] || return 0
+	if [[ -f ./rapido ]]; then
+		# assume git clone with cut subdirectory
+		cut_dir="./cut"
+	elif [[ -x /usr/bin/rapido ]]; then
+		# assume distro package with bin symlink to RAPIDO_DIR
+		bin="$(realpath -e /usr/bin/rapido)"
+		cut_dir="${bin%/*}/cut"
+	else
+		return 0
+	fi
 
-	cut_dir="${bin%/*}/cut"
-	[ -d "${cut_dir}" ] || return 0
+	[ -d "$cut_dir" ] || return 0
 
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"

--- a/tools/bash_completion
+++ b/tools/bash_completion
@@ -1,4 +1,3 @@
-#!/bin/bash
 # SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
 # Copyright (C) SUSE LLC 2019-2022, all rights reserved.
 


### PR DESCRIPTION
An attempt to address https://github.com/rapido-linux/rapido/issues/204 . Packages based on this RFC can be found at:
https://build.opensuse.org/package/show/home:dmdiss:rapido/rapido

```
The following changes since commit 7a71765ebcf2302962c7ec89432999f6400e73b0:

  autorun/ceph: load rbd module prior to sysfs IO (2023-09-11 12:31:33 +0200)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git distro_pkg

for you to fetch changes up to 9eba94f75bca048a28b2d355060afd73f2e8edc0:

  tools/bash_completion: support rapido binary in PATH (2023-09-21 16:40:37 +0200)

----------------------------------------------------------------
David Disseldorp (4):
      build: add Makefile for install target
      build: generate and install /etc/rapido/rapido.conf
      runtime: use /etc/rapido/rapido.conf RAPIDO_CONF if present
      tools/bash_completion: support rapido binary in PATH

 Makefile              | 42 ++++++++++++++++++++++++++++++++++++++++++
 runtime.vars          |  8 ++++++--
 tools/bash_completion |  4 ++--
 3 files changed, 50 insertions(+), 4 deletions(-)
 create mode 100644 Makefile
```