### PR TITLE
cut/fstests_xfs: include gcc and header files for xfs/122

### DIFF
--- a/cut/fstests_xfs.sh
+++ b/cut/fstests_xfs.sh
@@ -8,8 +8,8 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/fstests.sh" \
 			"$RAPIDO_DIR/autorun/fstests_xfs.sh" "$@"
 _rt_require_fstests
-pam_paths=()
-_rt_require_pam_mods pam_paths "pam_rootok.so" "pam_limits.so"
+req_inst=()
+_rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so"
 _rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
 	|| _fail "failed to calculate memory resources"
 # 2x multiplier for one test and one scratch zram. +2G as buffer
@@ -21,6 +21,12 @@ man_deps=(man /etc/manpath.config \
 [[ ${man_deps[@]} == ${man_deps[@]%.bz2} ]] || man_deps+=(bzcat)
 [[ ${man_deps[@]} == ${man_deps[@]%.xz} ]] || man_deps+=(xzcat)
 
+# xfs/122: pull in compiler and xfs headers
+_rt_require_gcc req_inst stdio.h xfs/xfs.h xfs/xfs_types.h xfs/xfs_fs.h \
+	xfs/xfs_arch.h xfs/xfs_format.h xfs/linux.h
+# xfs/122: catch any headers which might be new
+req_inst+=("/usr/include/xfs/*.h")
+
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
 		   strace mkfs mkfs.xfs free ip su uuidgen \
 		   which perl awk bc touch cut chmod true false unlink \
@@ -31,11 +37,11 @@ man_deps=(man /etc/manpath.config \
 		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
 		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
 		   repquota setquota quotacheck quotaon pvremove vgremove \
-		   xfs_mkfile xfs_db xfs_io xfs_spaceman fsck \
+		   xfs_mkfile xfs_db xfs_io xfs_spaceman fsck comm indent \
 		   xfs_mdrestore xfs_bmap xfs_fsr xfsdump xfs_freeze xfs_info \
 		   xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_metadump \
 		   chgrp du fgrep pgrep tar rev kill duperemove ${man_deps[*]} \
-		   ${pam_paths[*]} ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${req_inst[*]} ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
 		   ${FSTESTS_SRC}/src/log-writes/* \
 		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
 	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \

--- a/runtime.vars
+++ b/runtime.vars
@@ -460,6 +460,40 @@ _rt_require_samba_ctdb() {
 	[ -d "$CTDB_EVENTS_DIR" ] || _fail "$CTDB_EVENTS_DIR missing"
 }
 
+# Determine gcc compiler dependencies and append them to the list ref $1.
+# $2... is an ordered list of header files to obtain via "gcc -M" compilation,
+# which outputs full paths for all recursive includes.
+_rt_require_gcc() {
+	local hdr_incs hdr_paths
+	declare -n req_inst_ref="$1" || _fail "output ref parameter required"
+	shift
+	(( $# > 0 )) && printf -v hdr_incs '#include <%s>\n' "$@"
+	hdr_paths=$(gcc -x c -M - <<<"
+#define _GNU_SOURCE
+$hdr_incs
+int main(void) {return 0;}") || _fail "$hdr_incs compilation failed"
+	# trim gcc's '-:' srcfile prefix and '\' newline markers
+	hdr_paths=${hdr_paths#-:}
+	req_inst_ref+=( ${hdr_paths//\\/} )
+
+	# XXX: this looks very flakey and version specific
+	req_inst_ref+=("gcc" "cc"
+		$(gcc -print-prog-name=cc1;
+		gcc -print-prog-name=as;
+		gcc -print-prog-name=ld;
+		gcc -print-file-name=liblto_plugin.so;
+		gcc -print-file-name=crt1.o;
+		gcc -print-file-name=crti.o;
+		gcc -print-file-name=crtbegin.o;
+		gcc -print-file-name=crtend.o;
+		gcc -print-file-name=crtn.o;
+		gcc -print-file-name=libc.so;
+		gcc -print-file-name=libc_nonshared.a;
+		gcc -print-file-name=libgcc_s.so;
+		gcc -print-libgcc-file-name)
+	)
+}
+
 # TODO remove this: it's only used for qemu-rbd, which could instead rely on
 # custom configuration via rapido.conf:QEMU_EXTRA_ARGS
 _rt_qemu_custom_args_set() {


### PR DESCRIPTION
xfs/122 uses the compiler to examine XFS type sizes. Use gcc -M in the cut script to obtain a recursive list of all dependencies for /usr/include/xfs/ headers.