### PR TITLE
Fixup 'su -l' handling

### DIFF
--- a/autorun/lib/fstests.sh
+++ b/autorun/lib/fstests.sh
@@ -93,5 +93,10 @@ auth	sufficient	pam_rootok.so
 account	sufficient	pam_rootok.so
 session	required	pam_limits.so
 EOF
+	cat > /etc/pam.d/su-l <<EOF
+auth	sufficient	pam_rootok.so
+account	sufficient	pam_rootok.so
+session	required	pam_limits.so
+EOF
 	echo "# su needs this to exist" >> /etc/security/limits.conf
 }

--- a/autorun/lib/fstests.sh
+++ b/autorun/lib/fstests.sh
@@ -22,8 +22,10 @@ _fstests_devs_provision() {
 			 ["SCRATCH_RTDEV"]="" ["TEST_DEV"]="")
 
 	for i in $(ls /sys/block); do
-		ser="$(cat /sys/block/${i}/serial 2>/dev/null)" ||
-		ser="$(cat /sys/block/${i}/device/serial 2>/dev/null)" || continue
+		_ser="$(cat /sys/block/${i}/serial 2>/dev/null)" ||
+		    _ser="$(cat /sys/block/${i}/device/serial 2>/dev/null)" ||
+		    continue
+		ser=$(echo $_ser)
 		[[ -v "_CFG[$ser]" ]] && _CFG[$ser]="/dev/${i}"
 	done
 

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -44,12 +44,18 @@ function _vm_ar_env_check {
 # create /etc/hosts file with the essential IPv4 and IPv6 lines
 function _vm_ar_hosts_create
 {
-	local hostname_fqn="`cat /proc/sys/kernel/hostname`" \
+	local hostname_fqn
+	local hostname_short
+	local vm_domain
+
+	[ -f /etc/hosts ] && return
+
+	hostname_fqn="`cat /proc/sys/kernel/hostname`" \
 		|| _fatal "hostname unavailable"
 	# we don't put a fqdn in proc hostname, but maybe systemd?
-	local hostname_short="${hostname_fqn%%.*}"
+	hostname_short="${hostname_fqn%%.*}"
 
-	local vm_domain="$(cat /proc/sys/kernel/domainname)"
+	vm_domain="$(cat /proc/sys/kernel/domainname)"
 	if [ "$hostname_fqn" == "$hostname_short" ] && \
 	   [ -n "$vm_domain" ] && [ "$vm_domain" != "(none)" ]; then
 		hostname_fqn="${hostname_short}.${vm_domain}"
@@ -109,8 +115,13 @@ _vm_ar_hostname_set() {
 			|| domain="${kcli_rapido_hostname#*.}"
 	fi
 
-	echo "$hostname" > /proc/sys/kernel/hostname \
-		|| _fatal "failed to set hostname"
+	_hostname=$(cat /proc/sys/kernel/hostname)
+	if [ "$_hostname" = "$hostname" ]; then
+		domain=""
+	else
+		echo "$hostname" > /proc/sys/kernel/hostname \
+			|| _fatal "failed to set hostname"
+	fi
 	export HOSTNAME="$hostname"
 	if [ -n "$domain" ]; then
 		echo "$domain" > /proc/sys/kernel/domainname \
@@ -138,6 +149,7 @@ function _vm_ar_dyn_debug_enable
 function _vm_ar_virtfs_mount
 {
 	[ -z "$VIRTFS_SHARE_PATH" ] && return
+	[ -d /host ] && return
 
 	mkdir /host || _fatal "unable to create /host"
 	mount -t 9p host0 /host || _fatal "unable to mount host"
@@ -266,6 +278,8 @@ _vm_ar_load_kmods() {
 		|| kmods+=("virtio-rng")
 	[ -n "$VIRTFS_SHARE_PATH" ] && kmods+=("9pnet" "9pnet_virtio" "9p")
 	((${#kmods[*]} > 0)) && modprobe -a "${kmods[@]}"
+	export QEMU_EXTRA_ARGS=
+	export VIRTFS_SHARE_PATH=
 }
 
 _vm_ar_load_kmods
@@ -284,7 +298,8 @@ _vm_ar_virtfs_mount
 
 # The boot sequence is:
 # dracut -> 00-rapido-init.sh -> .profile (vm_autorun.env) -> /rapido_autorun/*
-for _f in /rapido_autorun/*; do
+for _f in /rapido_autorun/*.sh; do
+	[ -f "$_f" ] || continue
 	echo "Rapido: starting $_f"
-	[ -f "$_f" ] && . "$_f"
+	. "$_f" && mv "$_f" "${_f}.bak"
 done

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -156,7 +156,10 @@ function _vm_ar_virtfs_mount
 }
 
 _vm_ar_configfs_mount() {
-	modprobe configfs
+	cat /proc/filesystems | grep -m1 configfs &> /dev/null
+	if [ $? -ne 0 ]; then
+		modprobe configfs
+	fi
 	cat /proc/mounts | grep -m1 configfs &> /dev/null
 	if [ $? -ne 0 ]; then
 		mount -t configfs configfs /sys/kernel/config/
@@ -170,6 +173,7 @@ _vm_ar_network_setup() {
 	[[ -d /rapido-rsc/net ]] \
 		|| return	# networkless image
 
+	which modprobe &> /dev/null || return
 	modprobe -a virtio_net af_packet
 
 	mkdir -p /etc/systemd/ /run/systemd/
@@ -274,6 +278,7 @@ _vm_ar_ip_addrs_nomask() {
 _vm_ar_load_kmods() {
 	local -a kmods
 
+	which modprobe &> /dev/null || return
 	[ "$QEMU_EXTRA_ARGS" == "${QEMU_EXTRA_ARGS/virtio-rng-pci}" ] \
 		|| kmods+=("virtio-rng")
 	[ -n "$VIRTFS_SHARE_PATH" ] && kmods+=("9pnet" "9pnet_virtio" "9p")


### PR DESCRIPTION
xfstests is calling 'su -' on several locations, but the invocation will fail with 'su: Critical error - immediate abort'.
Primary reason is a missing /etc/pam.d/su-l, but we also make sure the /etc/profile doesn't attempt to setup the system twice.