### PR TITLE
autorun/init: start vm_autorun.env via bash --rcfile

### DIFF
--- a/autorun/00-rapido-init.sh
+++ b/autorun/00-rapido-init.sh
@@ -1,15 +1,5 @@
-#
-# Copyright (C) SUSE LLC 2020, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2020-2024, all rights reserved.
 
 # This script runs as the first Dracut entry point during /init.
 # $DRACUT_SYSTEMD is set when run via systemd.
@@ -24,7 +14,8 @@ for i in $(cat /proc/cmdline); do
 	esac
 done
 [ -c "$_ctty" ] || _ctty=/dev/tty1
-setsid --ctty /bin/sh -i -l 0<>$_ctty 1<>$_ctty 2<>$_ctty
+
+setsid --ctty -- /bin/bash --rcfile /rapido.rc -i 0<>$_ctty 1<>$_ctty 2<>$_ctty
 
 # shut down when rapido autorun / shell exits...
 echo 1 > /proc/sys/kernel/sysrq && echo o > /proc/sysrq-trigger

--- a/runtime.vars
+++ b/runtime.vars
@@ -272,7 +272,7 @@ _rt_require_dracut_args() {
 	local conf_src="$RAPIDO_CONF"
 	[[ -f $RAPIDO_CONF ]] || conf_src="${RAPIDO_DIR}/dracut.conf.d/.empty"
 	DRACUT_RAPIDO_ARGS+=(--include "$conf_src" /rapido.conf \
-			     --include "$env_src" /etc/profile \
+			     --include "$env_src" /rapido.rc \
 			     --include "$rinit_src" "$rinit_dst")
 
 	# start at 100 and strip first digit on use - hack for zero-padding

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -283,7 +283,7 @@ resize &> /dev/null
 _vm_ar_virtfs_mount
 
 # The boot sequence is:
-# dracut -> 00-rapido-init.sh -> .profile (vm_autorun.env) -> /rapido_autorun/*
+# dracut -> 00-rapido-init.sh -> rapido.rc (here) -> /rapido_autorun/*
 for _f in /rapido_autorun/*; do
 	echo "Rapido: starting $_f"
 	[ -f "$_f" ] && . "$_f"


### PR DESCRIPTION
Hanne's analysis:
  vm_autorun.env is copied into the rapido root fs as /etc/profile,
  and as such will be executed every time a login shell is invoked
  (ie via 'su -' or 'sh -l'). As this script also serves as system
  initialisation we need to make sure to run the initialisation only
  once, and only export the environment variables for later invocations.

To avoid multiple invocations, we can use bash's explicit --rcfile parameter when starting the initial shell, and install vm_autorun.env in a path where it won't get invoked automatically (/rapido.rc).

To use bash with --rcfile, we also need to drop the explicit --login/-l parameter, which changes bash behaviour slightly:
- (unused) profile paths are different
- legacy fcntl(fd=[3->19], F_SETFD, FD_CLOEXEC) calls are skipped

I *think* we shouldn't see any side-effects for rapido workloads.

Reported-by: Hannes Reinecke <hare@suse.de>