### PR TITLE
Preliminary distro packaging changes

### DIFF
--- a/rapido
+++ b/rapido
@@ -85,20 +85,17 @@ rapido_cut()
 		exit 1
 	fi
 
-	pushd "$RAPIDO_DIR" > /dev/null
-	cut_script="cut/${testname//-/_}.sh"
+	cut_script="${RAPIDO_DIR}/cut/${testname//-/_}.sh"
 
 	if [[ ! -x $cut_script ]]; then
 		[[ -f $cut_script ]] \
 		  && echo "$cut_script lacks execute permission." \
 		  || echo "$testname not found. See \"rapido list\"."
-		popd > /dev/null
 		exit
 	fi
 
-	./$cut_script "${post_autorun_files[@]}"
+	"$cut_script" "${post_autorun_files[@]}"
 	local cut_status=$?
-	popd > /dev/null
 	[ $cut_status -ne 0 ] && exit $cut_status
 	[ -n "$boot_img" ] || exit 0
 	"${RAPIDO_DIR}/vm.sh"
@@ -109,16 +106,13 @@ rapido_list()
 {
 	local t
 
-	pushd "$RAPIDO_DIR" > /dev/null
-
 	shopt -s nullglob
-	for t in cut/*.sh; do
-		[ -x "$t" ] || continue
+	for t in "$RAPIDO_DIR"/cut/*.sh; do
+		[[ -x "$t" ]] || continue
 		t="${t%.sh}"
-		t="${t//_/-}"
-		echo "${t#cut/}"
+		t="${t##*/cut/}"
+		echo "${t//_/-}"
 	done
-	popd > /dev/null
 }
 
 list_commands()

--- a/selftest/test/002
+++ b/selftest/test/002
@@ -8,7 +8,7 @@ set timeout 60
 spawn ./rapido cut -B simple-example
 expect {
 	timeout {exit 1}
-	"dracut: *** Creating initramfs image file"
+	"*** Creating initramfs image file"
 }
 expect {
 	timeout {exit 1}

--- a/tools/bash_completion
+++ b/tools/bash_completion
@@ -1,4 +1,3 @@
-#!/bin/bash
 # SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
 # Copyright (C) SUSE LLC 2019-2022, all rights reserved.
 


### PR DESCRIPTION
The first minor batch of changes moving rapido towards distro package support, cherry picked from https://github.com/rapido-linux/rapido/pull/228 .
I've tacked on one extra selftests fix to handle upstream dracut output changes.

```
The following changes since commit c4e0cff00bfdaea03b960311266db5f59f7c5390:

  usbip_host_stub: cut and autorun scripts (2024-11-25 13:59:18 +1100)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git prelim_distro_pkg

for you to fetch changes up to b33a5a1f5e80105bc5151b3827266d1a2cd9b78d:

  selftest/002: fix dracut-output needle (2024-11-26 15:52:33 +1100)

----------------------------------------------------------------
David Disseldorp (4):
      runtime: use /etc/rapido/rapido.conf RAPIDO_CONF if present
      tools/bash_completion: drop shebang
      rapido: don't cd into RAPIDO_DIR before cut invocation
      selftest/002: fix dracut-output needle

 rapido                | 18 ++++++------------
 runtime.vars          |  8 ++++++--
 selftest/test/002     |  2 +-
 tools/bash_completion |  1 -
 4 files changed, 13 insertions(+), 16 deletions(-)
```