### PR TITLE
nfs: fix client mounts and remove duplicate /etc/ config provisioning

### DIFF
--- a/autorun/fstests_nfs.sh
+++ b/autorun/fstests_nfs.sh
@@ -17,41 +17,7 @@ _fstests_users_groups_provision
 # use a non-configurable UID/GID for now
 nfs_xid="579121"
 nfs_user="nfsuser"
-cat >> /etc/passwd <<EOF
-rpc:x:464:65534:user for rpcbind:/var/lib/empty:/sbin/nologin
-statd:x:463:65533:NFS statd daemon:/var/lib/nfs:/sbin/nologin
-${nfs_user}:x:${nfs_xid}:${nfs_xid}:NFS user:/:/sbin/nologin
-EOF
-cat >> /etc/group <<EOF
-nobody:x:65534:
-nogroup:x:65533:nobody
-${nfs_user}:x:${nfs_xid}:
-EOF
-
-cat >> /etc/services <<EOF
-nfs	2049/tcp
-nfs	2049/udp
-sunrpc	111/tcp	rpcbind
-sunrpc	111/udp	rpcbind
-EOF
-
-cat >  /etc/netconfig <<EOF
-udp        tpi_clts      v     inet     udp     -       -
-tcp        tpi_cots_ord  v     inet     tcp     -       -
-udp6       tpi_clts      v     inet6    udp     -       -
-tcp6       tpi_cots_ord  v     inet6    tcp     -       -
-rawip      tpi_raw       -     inet      -      -       -
-local      tpi_cots_ord  -     loopback  -      -       -
-unix       tpi_cots_ord  -     loopback  -      -       -
-EOF
-
-cat >> /etc/nsswitch.conf <<EOF
-rpc:	files usrfiles
-EOF
-
-echo > /etc/hosts.allow <<EOF
-rpcbind : ALL : ALLOW
-EOF
+_nfs_etc_files_setup "$nfs_xid" "$nfs_user"
 
 set -x
 

--- a/autorun/lib/nfs.sh
+++ b/autorun/lib/nfs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2024, all rights reserved.
+
+_nfs_etc_files_setup() {
+	local xid="$1"	# UID/GID
+	local user="$2"
+
+	cat >> /etc/passwd <<EOF
+rpc:x:464:65534:user for rpcbind:/var/lib/empty:/sbin/nologin
+statd:x:463:65533:NFS statd daemon:/var/lib/nfs:/sbin/nologin
+${user}:x:${xid}:${xid}:NFS user:/:/sbin/nologin
+EOF
+	cat >> /etc/group <<EOF
+nobody:x:65534:
+nogroup:x:65533:nobody
+${user}:x:${xid}:
+EOF
+
+	cat >> /etc/services <<EOF
+nfs	2049/tcp
+nfs	2049/udp
+sunrpc	111/tcp	rpcbind
+sunrpc	111/udp	rpcbind
+EOF
+
+	cat > /etc/netconfig <<EOF
+udp        tpi_clts      v     inet     udp     -       -
+tcp        tpi_cots_ord  v     inet     tcp     -       -
+udp6       tpi_clts      v     inet6    udp     -       -
+tcp6       tpi_cots_ord  v     inet6    tcp     -       -
+rawip      tpi_raw       -     inet      -      -       -
+local      tpi_cots_ord  -     loopback  -      -       -
+unix       tpi_cots_ord  -     loopback  -      -       -
+EOF
+
+	cat > /etc/nsswitch.conf <<EOF
+rpc:	files usrfiles
+EOF
+
+	echo > /etc/hosts.allow <<EOF
+rpcbind : ALL : ALLOW
+EOF
+}

--- a/autorun/lib/nfs.sh
+++ b/autorun/lib/nfs.sh
@@ -34,6 +34,11 @@ local      tpi_cots_ord  -     loopback  -      -       -
 unix       tpi_cots_ord  -     loopback  -      -       -
 EOF
 
+	cat > /etc/protocols <<EOF
+tcp 6 TCP
+udp 17 UDP
+EOF
+
 	cat > /etc/nsswitch.conf <<EOF
 rpc:	files usrfiles
 EOF

--- a/autorun/nfs_client.sh
+++ b/autorun/nfs_client.sh
@@ -15,41 +15,7 @@ _vm_ar_hosts_create
 # use a non-configurable UID/GID for now
 nfs_xid="579121"
 nfs_user="nfsuser"
-cat >> /etc/passwd <<EOF
-rpc:x:464:65534:user for rpcbind:/var/lib/empty:/sbin/nologin
-statd:x:463:65533:NFS statd daemon:/var/lib/nfs:/sbin/nologin
-${nfs_user}:x:${nfs_xid}:${nfs_xid}:NFS user:/:/sbin/nologin
-EOF
-cat >> /etc/group <<EOF
-nobody:x:65534:
-nogroup:x:65533:nobody
-${nfs_user}:x:${nfs_xid}:
-EOF
-
-cat >> /etc/services <<EOF
-nfs	2049/tcp
-nfs	2049/udp
-sunrpc	111/tcp	rpcbind
-sunrpc	111/udp	rpcbind
-EOF
-
-cat >  /etc/netconfig <<EOF
-udp        tpi_clts      v     inet     udp     -       -
-tcp        tpi_cots_ord  v     inet     tcp     -       -
-udp6       tpi_clts      v     inet6    udp     -       -
-tcp6       tpi_cots_ord  v     inet6    tcp     -       -
-rawip      tpi_raw       -     inet      -      -       -
-local      tpi_cots_ord  -     loopback  -      -       -
-unix       tpi_cots_ord  -     loopback  -      -       -
-EOF
-
-cat > /etc/nsswitch.conf <<EOF
-rpc:	files usrfiles
-EOF
-
-echo > /etc/hosts.allow <<EOF
-rpcbind : ALL : ALLOW
-EOF
+_nfs_etc_files_setup "$nfs_xid" "$nfs_user"
 
 set -x
 

--- a/cut/fstests_nfs.sh
+++ b/cut/fstests_nfs.sh
@@ -6,6 +6,7 @@ RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
 _rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/fstests.sh" \
+			"$RAPIDO_DIR/autorun/lib/nfs.sh" \
 			"$RAPIDO_DIR/autorun/fstests_nfs.sh" "$@"
 _rt_require_fstests
 pam_paths=()

--- a/cut/nfs_client.sh
+++ b/cut/nfs_client.sh
@@ -5,7 +5,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/nfs_client.sh" "$@"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/nfs.sh" \
+			"$RAPIDO_DIR/autorun/nfs_client.sh" "$@"
 _rt_require_networking
 
 "$DRACUT" --install "tail ps rmdir resize dd vim grep find df du truncate \

--- a/cut/nfsd_btrfs.sh
+++ b/cut/nfsd_btrfs.sh
@@ -5,7 +5,8 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/nfsd_btrfs.sh" "$@"
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/nfs.sh" \
+			"$RAPIDO_DIR/autorun/nfsd_btrfs.sh" "$@"
 _rt_require_networking
 _rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
 	|| _fail "failed to calculate memory resources"


### PR DESCRIPTION
```
The following changes since commit ec3ad7557ed657007be05a12abacf83801516873:

  runtime: fix network dependency check (2024-12-03 10:29:17 +1100)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git nfs_fix_mount

for you to fetch changes up to 5af4b4be79cc3e585cd730e288285aa6ea2972d6:

  autorun/lib/nfs: setup /etc/protocols to fix mount (2024-12-03 16:15:09 +1100)

----------------------------------------------------------------
David Disseldorp (2):
      autorun/nfs: split out /etc/ config helper
      autorun/lib/nfs: setup /etc/protocols to fix mount

 autorun/fstests_nfs.sh | 36 +-----------------------------------
 autorun/lib/nfs.sh     | 49 +++++++++++++++++++++++++++++++++++++++++++++++++
 autorun/nfs_client.sh  | 36 +-----------------------------------
 autorun/nfsd_btrfs.sh  | 32 +-------------------------------
 cut/fstests_nfs.sh     |  1 +
 cut/nfs_client.sh      |  3 ++-
 cut/nfsd_btrfs.sh      |  3 ++-
 7 files changed, 57 insertions(+), 103 deletions(-)
 create mode 100644 autorun/lib/nfs.sh
```