### PR TITLE
Make /usr writable in /usr images with systemd (again)

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -273,7 +273,8 @@ _rt_require_dracut_args() {
 	[[ -f $RAPIDO_CONF ]] || conf_src="${RAPIDO_DIR}/dracut.conf.d/.empty"
 	DRACUT_RAPIDO_ARGS+=(--include "$conf_src" /rapido.conf \
 			     --include "$env_src" /rapido.rc \
-			     --include "$rinit_src" "$rinit_dst")
+			     --include "$rinit_src" "$rinit_dst"\
+			     --include "${RAPIDO_DIR}/systemd/system.conf.d/60-rapido.conf" "/etc/systemd/system.conf.d/60-rapido.conf")
 
 	# start at 100 and strip first digit on use - hack for zero-padding
 	local i=100

--- a/systemd/system.conf/60-rapido.conf
+++ b/systemd/system.conf/60-rapido.conf
@@ -1,0 +1,2 @@
+[Manager]
+ProtectSystem=false


### PR DESCRIPTION
systemd v256 made /usr inside initrds immutable with RO-mount but this may be undesired for rapido test images with systemd. Let's ship a systemd drop-in that disables this /usr protection.

I hesitate with this workaround since it adds the drop-in unconditionally whereas it's only needed with `dracut-systemd` module, I don't know how to filter that.