### PR TITLE
lklfuse_udev_usb: cut and autorun scripts

### DIFF
--- a/autorun/lklfuse_udev_usb.sh
+++ b/autorun/lklfuse_udev_usb.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+_vm_ar_hosts_create
+
+# XXX lklfuse-mount@.service should be able to use the
+# After/Requires=modprobe@fuse.service for /dev/fuse presence, except the mode
+# is only changed to 0666 by a 50-udev-default.rules fuse rule, which may be
+# processed *after* lklfuse-mount@.service proceeds. Even with modprobe here
+# lklfuse is still failing with /dev/fuse ENOPERM, but works on second attempt.
+modprobe -a usb-storage xhci-hcd xhci-pci fuse
+_vm_ar_dyn_debug_enable
+
+_users_groups_provision() {
+	local ug xid="2000"
+
+	echo "daemon:x:2:2:Daemon:/:/sbin/nologin" >> /etc/passwd
+	echo -e "root:x:0:\ndaemon:x:2:" >> /etc/group
+	for ug in lklfuse person; do
+		echo "${ug}:x:${xid}:${xid}:${ug} user:/:/bin/bash" \
+			>> /etc/passwd
+		echo "${ug}:x:${xid}:lklfusemember" >> /etc/group
+		((xid++))
+	done
+	for ug in lklfusemember; do
+		echo "${ug}:x:${xid}:${xid}:${ug} user:/:/bin/bash" \
+			>> /etc/passwd
+		echo "${ug}:x:${xid}:" >> /etc/group
+		((xid++))
+	done
+}
+
+_users_groups_provision
+
+# fuse by default won't allow access to non-mounters, we need to set:
+echo user_allow_other >> /etc/fuse3.conf
+
+set +x
+
+systemctl start systemd-udevd
+udevadm settle

--- a/cut/lklfuse_udev_usb.sh
+++ b/cut/lklfuse_udev_usb.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+#
+# Mount a USB attached block device as an unprivileged user via lklfuse.
+# The mount is triggered via udev:61-lklfuse.rules->lklfuse-mount@.service .
+#
+# The USB device can be virtual, e.g.
+# -drive if=none,id=stick,format=raw,file=/path/to/file.img \
+# -device nec-usb-xhci,id=xhci                              \
+# -device usb-storage,bus=xhci.0,drive=stick
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lklfuse_udev_usb.sh" "$@"
+_rt_require_conf_dir LKL_SRC
+req_inst=()
+_rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so" "pam_deny.so"
+_rt_mem_resources_set "2048M"
+
+tmpd="$(mktemp -d --tmpdir lklfuse_tmp.XXXXX)"
+pam_su="${tmpd}/su"
+pam_other="${tmpd}/other"
+etc_nsswitch="${tmpd}/nsswitch.conf"
+trap "rm $pam_su $pam_other $etc_nsswitch ; rmdir $tmpd" 0
+
+cat > $pam_su <<EOF
+auth	sufficient	pam_rootok.so
+account	sufficient	pam_rootok.so
+session	required	pam_limits.so
+EOF
+
+for i in auth account password session; do
+	echo "$i required pam_deny.so" >> $pam_other
+done
+
+cat > $etc_nsswitch <<EOF
+passwd: files
+group: files
+EOF
+
+# lklfuse is installed and included... --install to pull in libs (libfuse3) and
+# --include to place it in /usr/bin path used by the systemd service.
+# loadkeys is run via systemd-vconsole-setup.service. Use true as an alias to
+# avoid unnecessarily needing to install kbd maps.
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep dirname df \
+		   mktemp date file /usr/share/file/magic.mgc strings id find \
+		   strace mkfs mkfs.xfs shuf free su uuidgen losetup ipcmk \
+		   which awk touch cut chmod true false unlink lsusb tee gzip \
+		   ${LKL_SRC}/tools/lkl/lklfuse \
+		   ${req_inst[*]}" \
+	--include ${LKL_SRC}/tools/lkl/lklfuse /usr/bin/lklfuse \
+	--include "${LKL_SRC}/tools/lkl/systemd/lklfuse-mount@.service" \
+		  "/usr/lib/systemd/system/lklfuse-mount@.service" \
+	--include "${LKL_SRC}/tools/lkl/systemd/61-lklfuse.rules" \
+		  "/usr/lib/udev/rules.d/61-lklfuse.rules" \
+	--include "$pam_su" /etc/pam.d/su \
+	--include "$pam_su" /etc/pam.d/su-l \
+	--include "$pam_other" /etc/pam.d/other \
+	--include "$etc_nsswitch" /etc/nsswitch.conf \
+	--include "${RAPIDO_DIR}/dracut.conf.d/.empty" \
+		  /etc/security/limits.conf \
+	--include "${RAPIDO_DIR}/dracut.conf.d/.empty" /etc/login.defs \
+	--include /usr/bin/true /usr/bin/loadkeys \
+	--add-drivers "fuse usb-storage xhci-hcd xhci-pci" \
+	--modules "base dracut-systemd" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"
+
+# XXX: dracut strips setuid mode flags, so we append fusermount3 manually.
+# An alternative would be to configure systemd with ProtectSystem=false and
+# manually chmod.
+fum3=$(type -P fusermount3) || _fail
+echo "$fum3" | cpio --create -H newc >> "$DRACUT_OUT" || _fail

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -357,3 +357,9 @@ LTP_DIR="/opt/ltp"
 # https://github.com/openSUSE/sys-param-check .
 #SYS_PARAM_CHECK_SRC=
 ############################################
+
+############# lklfuse-udev-usb ############
+# Path to a build of the Linux Kernel Library (LKL) source available at
+# https://github.com/lkl/linux .
+#LKL_SRC=
+###########################################


### PR DESCRIPTION
Install lklfuse and the corresponding udev/systemd logic to mount USB attached block devices from an unprivileged user-space process. A new LKL_SRC rapido.conf parameter is added for obtaining lkl dependencies.