### PR TITLE
LKL testing improvements

### DIFF
--- a/autorun/initramfs_verify.sh
+++ b/autorun/initramfs_verify.sh
@@ -15,5 +15,8 @@ if [ -d "/fiod.mtime_chk" ]; then
 	[ "$(stat -c %Y /fiod.mtime_chk/2)" == "1641548272" ] || _fatal
 fi
 
+fio --name=verify-rd --rw=read --size=1M --verify=crc32c --filename=/fiod2 \
+	|| _fatal
+
 set +x
 echo "fio data verification successful"

--- a/autorun/lkl_tests.sh
+++ b/autorun/lkl_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+modprobe fuse
+_vm_ar_dyn_debug_enable
+
+set +x
+
+# USER used for net-setup.sh TAP_USER
+export USER=root
+cd "${LKL_SRC}/tools/lkl/tests"
+
+cat <<EOF
+Ready for LKL testing.
+
+E.g. to run all tests:
+  find . -type f -executable -name '*.sh' -exec '{}' ';'
+EOF

--- a/cut/initramfs_verify.sh
+++ b/cut/initramfs_verify.sh
@@ -40,3 +40,10 @@ if ! grep -q "^# CONFIG_INITRAMFS_PRESERVE_MTIME" "$kconfig"; then
 	  | cpio -o -H newc -D "$tmp_vdata"  >> "$DRACUT_OUT" \
 		|| _fail "failed to append mtime_chk archive"
 fi
+
+# compressed cpio archives can be mixed with uncompressed...
+fio --directory="${tmp_vdata}" --aux-path="${tmp_vdata}" \
+	--name=verify-wr --rw=write --size=1M --verify=crc32c \
+	--filename=fiod2 || _fail "fio failed to write verification data"
+echo -e "fiod2" | cpio -o -H newc -D "$tmp_vdata" | gzip >> "$DRACUT_OUT" \
+	|| _fail "failed to append compressed archive"

--- a/cut/lkl_tests.sh
+++ b/cut/lkl_tests.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+#
+# Environment to run LKL unit tests.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lkl_tests.sh" "$@"
+_rt_require_conf_dir LKL_SRC
+req_inst=()
+_rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so" "pam_deny.so"
+_rt_mem_resources_set "2048M"
+
+tmpd="$(mktemp -d --tmpdir lklfuse_tmp.XXXXX)"
+pam_su="${tmpd}/su"
+pam_other="${tmpd}/other"
+etc_nsswitch="${tmpd}/nsswitch.conf"
+sudo_fake="${tmpd}/sudo.fake"
+trap "rm $pam_su $pam_other $etc_nsswitch $sudo_fake ; rmdir $tmpd" 0
+
+cat > $pam_su <<EOF
+auth	sufficient	pam_rootok.so
+account	sufficient	pam_rootok.so
+session	required	pam_limits.so
+EOF
+
+for i in auth account password session; do
+	echo "$i required pam_deny.so" >> $pam_other
+done
+
+cat > $etc_nsswitch <<EOF
+passwd: files
+group: files
+EOF
+
+cat > "$sudo_fake" <<EOF
+#!/bin/bash -x
+if (( \$UID != 0 )); then
+	echo "error: fake sudo only works as root!"
+	exit 1
+fi
+
+#echo "fake sudo running: \$@"
+\$@
+EOF
+chmod 755 "$sudo_fake"
+
+# 'file' uses external magic metadata, install it if present.
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep dirname df id \
+		   mktemp date file strings find xfs_io mkfifo ping ping6 ip \
+		   strace mkfs mkfs.ext4 shuf free su uuidgen losetup ipcmk \
+		   which awk touch cut chmod true false unlink lsusb tee gzip \
+		   yes wc tc \
+		   ${LKL_SRC}/tools/lkl/lklfuse \
+		   ${LKL_SRC}/tools/lkl/tests/* \
+		   ${LKL_SRC}/tools/lkl/bin/lkl-hijack.sh \
+		   ${LKL_SRC}/tools/lkl/lib/hijack/liblkl-hijack.so \
+		   ${req_inst[*]}" \
+	--install-optional /usr/share/file/magic.mgc \
+	--install-optional /usr/share/misc/magic.mgc \
+	--install-optional /usr/share/misc/magic \
+	--install-optional netperf \
+	--include ${LKL_SRC}/tools/lkl/lib/liblkl.so /lib/liblkl.so \
+	--include "$pam_su" /etc/pam.d/su \
+	--include "$pam_su" /etc/pam.d/su-l \
+	--include "$pam_other" /etc/pam.d/other \
+	--include "$etc_nsswitch" /etc/nsswitch.conf \
+	--include "$sudo_fake" /bin/sudo \
+	--include "${RAPIDO_DIR}/dracut.conf.d/.empty" \
+		  /etc/security/limits.conf \
+	--include "${RAPIDO_DIR}/dracut.conf.d/.empty" /etc/login.defs \
+	--add-drivers "fuse" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"
+
+# XXX: dracut strips setuid mode flags, so we append fusermount3 manually.
+# An alternative would be to configure systemd with ProtectSystem=false and
+# manually chmod.
+fum3=$(type -P fusermount3) || _fail
+echo "$fum3" | cpio --create -H newc >> "$DRACUT_OUT" || _fail

--- a/cut/lklfuse_udev_usb.sh
+++ b/cut/lklfuse_udev_usb.sh
@@ -44,12 +44,16 @@ EOF
 # --include to place it in /usr/bin path used by the systemd service.
 # loadkeys is run via systemd-vconsole-setup.service. Use true as an alias to
 # avoid unnecessarily needing to install kbd maps.
+# 'file' uses external magic metadata, install it if present.
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep dirname df \
-		   mktemp date file /usr/share/file/magic.mgc strings id find \
+		   mktemp date file strings id find xfs_io \
 		   strace mkfs mkfs.xfs shuf free su uuidgen losetup ipcmk \
 		   which awk touch cut chmod true false unlink lsusb tee gzip \
 		   ${LKL_SRC}/tools/lkl/lklfuse \
 		   ${req_inst[*]}" \
+	--install-optional /usr/share/file/magic.mgc \
+	--install-optional /usr/share/misc/magic.mgc \
+	--install-optional /usr/share/misc/magic \
 	--include ${LKL_SRC}/tools/lkl/lklfuse /usr/bin/lklfuse \
 	--include "${LKL_SRC}/tools/lkl/systemd/lklfuse-mount@.service" \
 		  "/usr/lib/systemd/system/lklfuse-mount@.service" \


### PR DESCRIPTION
v2: I've tacked on one extra initramfs-verify change

```
The following changes since commit c9337a55e90e60716f2d27613f6a078326f956ac:

  Merge branch 'lklfuse' (2025-02-27 23:39:38 +1100)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git lkl_tests

for you to fetch changes up to 1c4ed65ea6f88a5a1623b2645c41084f8134eeac:

  initramfs_verify: compressed cpio after uncompressed (2025-03-29 00:45:22 +1100)

----------------------------------------------------------------
David Disseldorp (3):
      cut/lklfuse_udev_usb: use install-optional for file magic.mgc
      lkl_tests: cut and autorun
      initramfs_verify: compressed cpio after uncompressed

 autorun/initramfs_verify.sh |  3 ++
 autorun/lkl_tests.sh        | 23 +++++++++++++
 cut/initramfs_verify.sh     |  7 ++++
 cut/lkl_tests.sh            | 83 +++++++++++++++++++++++++++++++++++++++++++++
 cut/lklfuse_udev_usb.sh     |  6 +++-
 5 files changed, 121 insertions(+), 1 deletion(-)
 create mode 100755 autorun/lkl_tests.sh
 create mode 100755 cut/lkl_tests.sh
```