### PR TITLE
runtime: Specify vCPUs with explicit (socket) topology

### DIFF
--- a/runtime.vars
+++ b/runtime.vars
@@ -571,7 +571,8 @@ _rt_qemu_resources_get() {
 		fi
 	done
 
-	args_ref+=(-smp "cpus=${cpus}" -m "$mem" $custom_args)
+	# coarse topology for non-ACPI guests
+	args_ref+=(-smp "${cpus},sockets=${cpus},cores=1,threads=1" -m "$mem" $custom_args)
 }
 
 _rt_human_size_in_b() {


### PR DESCRIPTION
When only number of CPUs is specified, qemu chooses some topology. The issue is when running a kernel without ACPI support that cannot obtain the topology from ACPI data, it falls back to parsing legacy mptable and this format cannot convey more that 1 core per socket (qemu's BIOS rejects changing this [1]).

The implicit topology used to work with qemu <6.2 which prefered sockets over cores but it doesn't in later versions which put cores above sockets.

Therefore synthesize the coarsest topology in rapido's resource helper, so that non-ACPI kernels can detect right number of vCPUs.

[1] https://www.mail-archive.com/seabios@seabios.org/msg13239.html