### PR TITLE
lkl: remount /dev/shm without noexec

### DIFF
--- a/autorun/lkl_tests.sh
+++ b/autorun/lkl_tests.sh
@@ -11,6 +11,11 @@ _vm_ar_dyn_debug_enable
 
 set +x
 
+# Dracut mounts /dev/shm with noexec. drop it for arch/lkl/mm/mmu_mem.c
+# mmap_pages_for_ptes() which calls shmem_mmap() with PROT_EXEC:
+# https://github.com/lkl/linux/issues/606
+mount -t tmpfs -o remount,mode=1777,nosuid,nodev,strictatime tmpfs /dev/shm
+
 # USER used for net-setup.sh TAP_USER
 export USER=root
 cd "${LKL_SRC}/tools/lkl/tests"

--- a/autorun/lklfuse_udev_usb.sh
+++ b/autorun/lklfuse_udev_usb.sh
@@ -42,5 +42,8 @@ echo user_allow_other >> /etc/fuse3.conf
 
 set +x
 
+# Dracut mounts /dev/shm with noexec. drop it for arch/lkl/mm/mmu_mem.c
+mount -t tmpfs -o remount,mode=1777,nosuid,nodev,strictatime tmpfs /dev/shm
+
 systemctl start systemd-udevd
 udevadm settle

--- a/cut/lkl_tests.sh
+++ b/cut/lkl_tests.sh
@@ -50,9 +50,9 @@ chmod 755 "$sudo_fake"
 # 'file' uses external magic metadata, install it if present.
 "$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep dirname df id \
 		   mktemp date file strings find xfs_io mkfifo ping ping6 ip \
-		   strace mkfs mkfs.ext4 shuf free su uuidgen losetup ipcmk \
+		   strace shuf free su uuidgen losetup ipcmk \
 		   which awk touch cut chmod true false unlink lsusb tee gzip \
-		   yes wc tc \
+		   yes wc tc mkfs mkfs.ext4 mkfs.xfs mkfs.btrfs mkfs.vfat \
 		   ${LKL_SRC}/tools/lkl/lklfuse \
 		   ${LKL_SRC}/tools/lkl/tests/* \
 		   ${LKL_SRC}/tools/lkl/bin/lkl-hijack.sh \


### PR DESCRIPTION
LKL MMU=y mode calls mmap() with PROT_EXEC, so the Dracut noexec default causes LKL boot failure if retained.

Also add a few extra mkfs binaries for disk.sh -t $TYPE testing.