### PR TITLE
A few autofs runners

### DIFF
--- a/autorun/autofs_direct_cifs.sh
+++ b/autorun/autofs_direct_cifs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2022, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+modprobe autofs4
+_vm_ar_dyn_debug_enable
+
+creds_path="/tmp/cifs_creds"
+[ -n "$CIFS_DOMAIN" ] && echo "domain=${CIFS_DOMAIN}" >> $creds_path
+[ -n "$CIFS_USER" ] && echo "username=${CIFS_USER}" >> $creds_path
+[ -n "$CIFS_PW" ] && echo "password=${CIFS_PW}" >> $creds_path
+mount_args="-fstype=cifs,credentials=${creds_path}"
+[ -n "$CIFS_MOUNT_OPTS" ] && mount_args="${mount_args},${CIFS_MOUNT_OPTS}"
+set -x
+
+mkdir -p /etc/sysconfig /smb/share
+touch /etc/sysconfig/autofs	# avoid noise
+
+echo "automount: files" > /etc/nsswitch.conf
+echo "[ autofs ]" > /etc/autofs.conf
+
+cat > /etc/auto.master <<EOF
+/-	/etc/auto.direct
+EOF
+cat > /etc/auto.direct <<EOF
+/smb/share  $mount_args ://${CIFS_SERVER}/${CIFS_SHARE}
+EOF
+
+if [ -n "$AUTOFS_SRC" ]; then
+	for l in /usr/lib/autofs /usr/lib64/autofs; do
+		mkdir -p "$l"
+		pushd "$l"
+		ln -s ${AUTOFS_SRC}/lib/*.so .
+		ln -s ${AUTOFS_SRC}/modules/*.so .
+		# see autofs/modules/Makefile...
+		ln -s "lookup_file.so" "lookup_files.so"
+		popd
+	done
+	export PATH="${AUTOFS_SRC}/daemon:$PATH"
+fi
+
+automount --dumpmaps
+automount
+
+set +x

--- a/autorun/autofs_direct_nfs.sh
+++ b/autorun/autofs_direct_nfs.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+modprobe autofs4
+_vm_ar_dyn_debug_enable
+_vm_ar_hosts_create
+
+[[ -n $NFS_SERVER && -n $NFS_SHARE ]] \
+	|| _fatal "NFS_SERVER and NFS_SHARE must be set in rapido.conf"
+[[ -n $NFS_MOUNT_OPTS ]] && mount_args="-o${NFS_MOUNT_OPTS}"
+
+# use a non-configurable UID/GID for now
+nfs_xid="579121"
+nfs_user="nfsuser"
+_nfs_etc_files_setup "$nfs_xid" "$nfs_user"
+
+mkdir -p /etc/sysconfig /nfs/share
+touch /etc/sysconfig/autofs	# avoid noise
+
+echo "automount: files" > /etc/nsswitch.conf
+echo "[ autofs ]" > /etc/autofs.conf
+
+cat > /etc/auto.master <<EOF
+/-	/etc/auto.direct
+EOF
+cat > /etc/auto.direct <<EOF
+/nfs/share  $mount_args ${NFS_SERVER}:/${NFS_SHARE}
+EOF
+
+if [ -n "$AUTOFS_SRC" ]; then
+	for l in /usr/lib/autofs /usr/lib64/autofs; do
+		mkdir -p "$l"
+		pushd "$l"
+		ln -s ${AUTOFS_SRC}/lib/*.so .
+		ln -s ${AUTOFS_SRC}/modules/*.so .
+		# see autofs/modules/Makefile...
+		ln -s "lookup_file.so" "lookup_files.so"
+		popd
+	done
+	export PATH="${AUTOFS_SRC}/daemon:$PATH"
+fi
+
+automount --dumpmaps
+automount
+
+set +x

--- a/autorun/autofs_indirect_cifs.sh
+++ b/autorun/autofs_indirect_cifs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+modprobe autofs4
+_vm_ar_dyn_debug_enable
+
+creds_path="/tmp/cifs_creds"
+[ -n "$CIFS_DOMAIN" ] && echo "domain=${CIFS_DOMAIN}" >> $creds_path
+[ -n "$CIFS_USER" ] && echo "username=${CIFS_USER}" >> $creds_path
+[ -n "$CIFS_PW" ] && echo "password=${CIFS_PW}" >> $creds_path
+mount_args="-fstype=cifs,credentials=${creds_path}"
+[ -n "$CIFS_MOUNT_OPTS" ] && mount_args="${mount_args},${CIFS_MOUNT_OPTS}"
+set -x
+
+mkdir -p /etc/sysconfig /smb
+touch /etc/sysconfig/autofs	# avoid noise
+
+echo "automount: files" > /etc/nsswitch.conf
+echo "[ autofs ]" > /etc/autofs.conf
+
+cat > /etc/auto.master <<EOF
+/smb	/etc/auto.indirect.smb
+EOF
+cat > /etc/auto.indirect.smb <<EOF
+share ${mount_args} ://${CIFS_SERVER}/${CIFS_SHARE}
+EOF
+
+if [ -n "$AUTOFS_SRC" ]; then
+	for l in /usr/lib/autofs /usr/lib64/autofs; do
+		mkdir -p "$l"
+		pushd "$l"
+		ln -s ${AUTOFS_SRC}/lib/*.so .
+		ln -s ${AUTOFS_SRC}/modules/*.so .
+		# see autofs/modules/Makefile...
+		ln -s "lookup_file.so" "lookup_files.so"
+		popd
+	done
+	export PATH="${AUTOFS_SRC}/daemon:$PATH"
+fi
+
+automount --dumpmaps
+automount
+
+set +x

--- a/cut/autofs_direct_cifs.sh
+++ b/cut/autofs_direct_cifs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/autofs_direct_cifs.sh" "$@"
+_rt_require_networking
+req_inst=()
+_rt_require_autofs req_inst
+
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
+		   mount.cifs ip ping getfacl setfacl truncate du \
+		   which touch cut chmod true false unlink id \
+		   getfattr setfattr chacl attr killall sync strace \
+		   dirname seq basename fstrim chattr lsattr stat
+		   ${req_inst[*]}" \
+	--add-drivers "cifs ccm gcm ctr cmac autofs4" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/autofs_direct_nfs.sh
+++ b/cut/autofs_direct_nfs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/nfs.sh" \
+			"$RAPIDO_DIR/autorun/autofs_direct_nfs.sh" "$@"
+_rt_require_networking
+req_inst=()
+_rt_require_autofs req_inst
+
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
+		   mount.nfs ip ping getfacl setfacl truncate du \
+		   which touch cut chmod true false unlink id \
+		   getfattr setfattr chacl attr killall sync strace \
+		   dirname seq basename fstrim chattr lsattr stat
+		   ${req_inst[*]}" \
+	--add-drivers "nfs nfsv3 nfsv4 autofs4" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/cut/autofs_indirect_cifs.sh
+++ b/cut/autofs_indirect_cifs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2021, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/autofs_indirect_cifs.sh" "$@"
+_rt_require_networking
+req_inst=()
+_rt_require_autofs req_inst
+
+"$DRACUT" --install "tail ps rmdir resize dd vim grep find df \
+		   mount.cifs ip ping getfacl setfacl truncate du \
+		   which touch cut chmod true false unlink id \
+		   getfattr setfattr chacl attr killall sync strace \
+		   dirname seq basename fstrim chattr lsattr stat
+		   ${req_inst[*]}" \
+	--add-drivers "cifs ccm gcm ctr cmac autofs4" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -341,6 +341,12 @@ LTP_DIR="/opt/ltp"
 #NFS_MOUNT_OPTS=""
 ###############################################
 
+############## autorun/autofs*.sh ##############
+# Path to a build of the autofs user-space source available at
+# https://git.kernel.org/pub/scm/linux/storage/autofs/autofs.git/
+#AUTOFS_SRC=""
+###############################################
+
 ######### autorun/fstests_virtiofs.sh #########
 # mount options to use for virtiofs mount attempts.
 #VIRTIOFS_MOUNT_OPTS=""

--- a/runtime.vars
+++ b/runtime.vars
@@ -252,6 +252,22 @@ _rt_require_ksmbd_tools() {
 		|| _fail "missing ksmbd.tools binary"
 }
 
+_rt_require_autofs() {
+	declare -n req_inst_ref="$1" || _fail "output ref parameter required"
+	local p
+
+	if [ -n "$AUTOFS_SRC" ]; then
+		p="${AUTOFS_SRC}/daemon"
+		req_inst_ref+=(${AUTOFS_SRC}/modules/*.so ${AUTOFS_SRC}/lib/*.so)
+	else
+		p="${PATH}:/sbin:/usr/sbin"
+		req_inst_ref+=(/usr/lib64/autofs/*.so)
+	fi
+
+	req_inst_ref+=( $(PATH=$p type -P automount) ) \
+		|| _fail "missing autofs automount binary"
+}
+
 _rt_require_blktests() {
 	_rt_require_conf_dir BLKTESTS_SRC
 	[ -x "$BLKTESTS_SRC/check" ] || _fail "missing $BLKTESTS_SRC/check"


### PR DESCRIPTION
I've had these laying around for some time and had to dig them up again for a recent bug report.
```
The following changes since commit 8f62848e0a59f276430a153ddb5fec598cb05cc5:

  Merge remote-tracking branch 'lkl_mmu' into master (2025-06-11 21:42:32 +1000)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git autofs_filemaps

for you to fetch changes up to 4732c43fd166a1fac81d4395ea8337d31937bc15:

  autofs_direct_nfs: new cut and autorun scripts (2025-07-21 09:08:54 +1000)

----------------------------------------------------------------
David Disseldorp (3):
      autofs_indirect_cifs: local autofs map for SMB shares
      autofs_direct_cifs: local direct autofs map for SMB shares
      autofs_direct_nfs: new cut and autorun scripts

 autorun/autofs_direct_cifs.sh   | 47 +++++++++++++++++++++++++++++++++++++++
 autorun/autofs_direct_nfs.sh    | 49 +++++++++++++++++++++++++++++++++++++++++
 autorun/autofs_indirect_cifs.sh | 47 +++++++++++++++++++++++++++++++++++++++
 cut/autofs_direct_cifs.sh       | 22 ++++++++++++++++++
 cut/autofs_direct_nfs.sh        | 23 +++++++++++++++++++
 cut/autofs_indirect_cifs.sh     | 22 ++++++++++++++++++
 runtime.vars                    | 16 ++++++++++++++
 7 files changed, 226 insertions(+)
 create mode 100755 autorun/autofs_direct_cifs.sh
 create mode 100755 autorun/autofs_direct_nfs.sh
 create mode 100755 autorun/autofs_indirect_cifs.sh
 create mode 100755 cut/autofs_direct_cifs.sh
 create mode 100755 cut/autofs_direct_nfs.sh
 create mode 100755 cut/autofs_indirect_cifs.sh
```