### PR TITLE
vm_autorun.env: Provide shutdown handler with systemd

### DIFF
--- a/autorun/00-rapido-init.sh
+++ b/autorun/00-rapido-init.sh
@@ -18,5 +18,9 @@ done
 setsid --ctty -- /bin/bash --rcfile /rapido.rc -i 0<>$_ctty 1<>$_ctty 2<>$_ctty
 
 # shut down when rapido autorun / shell exits...
-echo 1 > /proc/sys/kernel/sysrq && echo o > /proc/sysrq-trigger
-sleep 20
+if [ -n "$DRACUT_SYSTEMD" ] ; then
+	kill -SIGRTMIN+4 1
+else
+	echo 1 > /proc/sys/kernel/sysrq && echo o > /proc/sysrq-trigger
+	sleep 20
+fi

--- a/vm_autorun.env
+++ b/vm_autorun.env
@@ -3,8 +3,13 @@
 
 . /rapido.conf
 
-alias shutdown='echo o > /proc/sysrq-trigger'
-alias reboot='echo b > /proc/sysrq-trigger'
+if [ -n "$DRACUT_SYSTEMD" ] ; then
+	alias shutdown='kill -SIGRTMIN+4 1'
+	alias reboot='kill -SIGRTMIN+5 1'
+else
+	alias shutdown='echo o > /proc/sysrq-trigger'
+	alias reboot='echo b > /proc/sysrq-trigger'
+fi
 alias vi='vim'
 alias view='vim -R'
 alias l='ls -la'


### PR DESCRIPTION
There are cuts that setup the environment with fully-fledged PID1 as systemd. Pulling the plug in such cases may or may not work depending on the ACPI support in the kernel/hypervisor.
The system may be left in not well-defined state when _only_ sysrq is invoked where most of the userspace is left running.

Fix this by detecting which kind of setup we're in and ask PID1 to nicely shut down (via signals to avoid dependency on systemctl).

---

The implementation is little rough but it prevents me ending up with borked VM.