### PR TITLE
Add CI with selftests in a container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
     container:
       image: registry.opensuse.org/home/mkoutny/containers/opensuse_containers_tumbleweed_containers/rapido-ci:latest
       env:
-        KERNEL_RELEASE: 6.16.7-1-default
         KERNEL_INSTALL_MOD_PATH: /usr/
       options:  -w /test
       volumes:
@@ -20,5 +19,5 @@ jobs:
 
       - name: Run selftest
         run: |
-          /test/selftest/selftest.sh
+          KERNEL_RELEASE=$(cat /usr/src/linux-obj/x86_64/default/include/config/kernel.release) /test/selftest/selftest.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.opensuse.org/home/mkoutny/containers/opensuse_containers_tumbleweed_containers/rapido-ci:latest
+      env:
+        KERNEL_RELEASE: 6.16.7-1-default
+        KERNEL_INSTALL_MOD_PATH: /usr/
+      options:  -w /test
+      volumes:
+        - ${{ github.workspace }}:/test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run selftest
+        run: |
+          /test/selftest/selftest.sh
+

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -1,10 +1,17 @@
 # Path to Linux kernel source. Prior to running "rapido cut", the kernel
 # should be built, with modules installed (see KERNEL_INSTALL_MOD_PATH below).
-# If KERNEL_SRC is not set then rapido will attempt to boot the local kernel
-# present under /boot/.
+# If KERNEL_SRC is not set then rapido will attempt to boot a host kernel
+# available under /boot/; either the `uname -r` release, or (if specified) the
+# KERNEL_RELEASE version.
 #
 # e.g. KERNEL_SRC="/home/me/linux"
 #KERNEL_SRC=""
+
+# Only applicable with an empty KERNEL_SRC. KERNEL_RELEASE can be used to
+# override which host kernel should be used, when left empty/unset defaults to
+# `uname -r`.
+# e.g. KERNEL_RELEASE="6.16.3-1-default"
+#KERNEL_RELEASE=""
 
 # If specified, this parameter defines the path that Dracut should use to
 # obtain compiled kernel modules. If left blank, Dracut will use its default

--- a/runtime.vars
+++ b/runtime.vars
@@ -308,6 +308,8 @@ _rt_require_dracut_args() {
 		kver="$(cat "${KERNEL_SRC}/include/config/kernel.release")"
 		[[ -n $kver ]] \
 			|| _fail "failed to read kernel.release at $KERNEL_SRC"
+	elif [[ -n $KERNEL_RELEASE ]] ; then
+		kver="$KERNEL_RELEASE"
 	else
 		kver="$(uname -r)"
 	fi
@@ -365,7 +367,12 @@ _rt_require_qemu_args() {
 		_rt_require_conf_dir KERNEL_SRC
 		f="$KERNEL_SRC/.config"
 	else
-		kver_sfx="-$(uname -r)"
+		if [[ -n $KERNEL_RELEASE ]] ; then
+			kver_sfx="-$KERNEL_RELEASE"
+		else
+			kver_sfx="-$(uname -r)"
+		fi
+
 		f="/boot/config${kver_sfx}"
 		[[ -r $f ]] \
 			|| _fail "unable to boot local kernel: $f inaccessible"


### PR DESCRIPTION
Followup to [this](https://github.com/rapido-linux/rapido/issues/254#issuecomment-3175282786)

One could install `kernel-default-devel` and `KERNEL_SRC=/usr/src/linux-6.16.3-1-obj/x86_64/default/` + tweak lookup of vmlinuz. Or teach rapido to use specific kernel version (commit in this PR) and then run the tests in a simple container image:

```Dockerfile
FROM registry.opensuse.org/opensuse/tumbleweed:latest
RUN zypper --non-interactive in dracut expect kernel-default 
RUN zypper --non-interactive in qemu-x86

# only needed with KERNEL_SRC override, won't work without further changes in rapido
# RUN zypper --non-interactive in kernel-source
# RUN zypper --non-interactive in kernel-devel
# RUN zypper --non-interactive in kernel-syms

CMD /test/selftest/selftest.sh
```

And then I can run selftests like:
```
docker run -v $PWD:/test -w /test \
    -e KERNEL_RELEASE=6.16.3-1-default
    -e KERNEL_INSTALL_MOD_PATH=/usr/
    localhost/rapido-test-image
```

### Next up:

- push the image somewhere
- [figure out how to make Github CI](https://stackoverflow.com/a/64200200) run actions inside said image
- possibly automate building/refreshing the image + automatic updated of KERNEL_RELEASE used in CI
