### PR TITLE
fstests_ovl_xfs: cut and autorun scripts

### DIFF
--- a/autorun/fstests_ovl_xfs.sh
+++ b/autorun/fstests_ovl_xfs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+
+_vm_ar_env_check || exit 1
+
+set -x
+
+modprobe nvme
+modprobe virtio_blk
+modprobe zram num_devices="0" || _fatal "failed to load zram module"
+
+_vm_ar_hosts_create
+_vm_ar_dyn_debug_enable
+
+_fstests_users_groups_provision
+
+fstests_cfg="${FSTESTS_SRC}/configs/$(hostname -s).config"
+cat > "$fstests_cfg" << EOF
+MODULAR=0
+TEST_DIR=/mnt/test
+SCRATCH_MNT=/mnt/scratch
+USE_KMEMLEAK=yes
+FSTYP=xfs
+MKFS_OPTIONS=
+EOF
+_fstests_devs_provision "$fstests_cfg"
+. "$fstests_cfg"
+
+mkdir -p "$TEST_DIR" "$SCRATCH_MNT"
+mkfs."${FSTYP}" $MKFS_OPTIONS -f "$TEST_DEV" || _fatal "mkfs failed"
+mount -t "$FSTYP" "$TEST_DEV" "$TEST_DIR" || _fatal
+
+# xfstests does *not* do scratch mkfs+mount for -overlayfs backing
+mkfs."${FSTYP}" $MKFS_OPTIONS -f "$SCRATCH_DEV" || _fatal "mkfs failed"
+
+# fstests generic/131 needs loopback networking
+ip link set dev lo up
+
+set +x
+
+echo "Ready for FSQA, e.g.: ./check -overlay"
+
+cd "$FSTESTS_SRC" || _fatal
+[[ -n "$FSTESTS_AUTORUN_CMD" ]] && eval "$FSTESTS_AUTORUN_CMD"

--- a/cut/fstests_ovl_xfs.sh
+++ b/cut/fstests_ovl_xfs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE LLC 2025, all rights reserved.
+
+RAPIDO_DIR="$(realpath -e ${0%/*})/.."
+. "${RAPIDO_DIR}/runtime.vars"
+
+_rt_require_dracut_args "$RAPIDO_DIR/autorun/lib/fstests.sh" \
+			"$RAPIDO_DIR/autorun/fstests_ovl_xfs.sh" "$@"
+req_inst=()
+_rt_require_fstests
+_rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so"
+_rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
+	|| _fail "failed to calculate memory resources"
+# 2x multiplier for one test and one scratch zram. +2G as buffer
+_rt_mem_resources_set "$((2048 + (zram_bytes * 2 / 1048576)))M"
+
+"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep find df sha256sum \
+		   strace mkfs mkfs.xfs free ip su uuidgen losetup ipcmk \
+		   which perl awk bc touch cut chmod true false unlink \
+		   mktemp getfattr setfattr chacl attr killall hexdump sync \
+		   id sort uniq date expr tac diff head dirname seq \
+		   basename tee egrep yes mkswap timeout blkdiscard \
+		   fstrim fio logger dmsetup chattr lsattr cmp stat \
+		   dbench /usr/share/dbench/client.txt hostname getconf md5sum \
+		   od wc getfacl setfacl tr xargs sysctl link truncate quota \
+		   repquota setquota quotacheck quotaon pvremove vgremove \
+		   xfs_mkfile xfs_db xfs_io xfs_spaceman fsck comm indent \
+		   xfs_mdrestore xfs_bmap xfs_fsr xfsdump xfs_freeze xfs_info \
+		   xfs_logprint xfs_repair xfs_growfs xfs_quota xfs_metadump \
+		   chgrp du fgrep pgrep tar rev kill duperemove python3 \
+		   ${req_inst[*]} ${FSTESTS_SRC}/ltp/* ${FSTESTS_SRC}/src/* \
+		   ${FSTESTS_SRC}/src/log-writes/* \
+		   ${FSTESTS_SRC}/src/aio-dio-regress/*" \
+	--include "$FSTESTS_SRC" "$FSTESTS_SRC" \
+	--add-drivers "zram nvme lzo lzo-rle dm-snapshot dm-flakey overlay xfs \
+		       loop scsi_debug dm-log-writes virtio_blk" \
+	--modules "base" \
+	"${DRACUT_RAPIDO_ARGS[@]}" \
+	"$DRACUT_OUT" || _fail "dracut failed"


### PR DESCRIPTION
Add xfs-backed-overlayfs runner for fstests. fstests can be used as a harness for the unionmount testsuite, but we already have unionmount_testsuite, so omit the testsuite from the image for now.