### PR TITLE
add journald to systemd manifest and convert lklfuse_udev_usb to use it

### DIFF
--- a/autorun/lklfuse_udev_usb.sh
+++ b/autorun/lklfuse_udev_usb.sh
@@ -11,31 +11,9 @@ _vm_ar_hosts_create
 # XXX lklfuse-mount@.service should be able to use the
 # After/Requires=modprobe@fuse.service for /dev/fuse presence, except the mode
 # is only changed to 0666 by a 50-udev-default.rules fuse rule, which may be
-# processed *after* lklfuse-mount@.service proceeds. Even with modprobe here
-# lklfuse is still failing with /dev/fuse ENOPERM, but works on second attempt.
+# processed *after* lklfuse-mount@.service proceeds.
 modprobe -a usb-storage xhci-hcd xhci-pci fuse
 _vm_ar_dyn_debug_enable
-
-_users_groups_provision() {
-	local ug xid="2000"
-
-	echo "daemon:x:2:2:Daemon:/:/sbin/nologin" >> /etc/passwd
-	echo -e "root:x:0:\ndaemon:x:2:" >> /etc/group
-	for ug in lklfuse person; do
-		echo "${ug}:x:${xid}:${xid}:${ug} user:/:/bin/bash" \
-			>> /etc/passwd
-		echo "${ug}:x:${xid}:lklfusemember" >> /etc/group
-		((xid++))
-	done
-	for ug in lklfusemember; do
-		echo "${ug}:x:${xid}:${xid}:${ug} user:/:/bin/bash" \
-			>> /etc/passwd
-		echo "${ug}:x:${xid}:" >> /etc/group
-		((xid++))
-	done
-}
-
-_users_groups_provision
 
 # fuse by default won't allow access to non-mounters, we need to set:
 echo user_allow_other >> /etc/fuse3.conf

--- a/cut/lklfuse_udev_usb.sh
+++ b/cut/lklfuse_udev_usb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
-# Copyright (C) SUSE LLC 2025, all rights reserved.
+# Copyright (C) SUSE S.A. 2025-2026, all rights reserved.
 #
 # Mount a USB attached block device as an unprivileged user via lklfuse.
 # The mount is triggered via udev:61-lklfuse.rules->lklfuse-mount@.service .
@@ -13,17 +13,17 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/lklfuse_udev_usb.sh" "$@"
-_rt_require_conf_dir LKL_SRC
 req_inst=()
 _rt_require_pam_mods req_inst "pam_rootok.so" "pam_limits.so" "pam_deny.so"
-_rt_mem_resources_set "2048M"
 
 tmpd="$(mktemp -d --tmpdir lklfuse_tmp.XXXXX)"
 pam_su="${tmpd}/su"
 pam_other="${tmpd}/other"
 etc_nsswitch="${tmpd}/nsswitch.conf"
-trap "rm $pam_su $pam_other $etc_nsswitch ; rmdir $tmpd" 0
+etc_passwd="${tmpd}/passwd"
+etc_group="${tmpd}/group"
+system_init_tgt="${tmpd}/system_init_tgt"
+trap "rm $pam_su $pam_other $etc_nsswitch $etc_passwd $etc_group $system_init_tgt; rmdir $tmpd" 0
 
 cat > $pam_su <<EOF
 auth	sufficient	pam_rootok.so
@@ -40,40 +40,123 @@ passwd: files
 group: files
 EOF
 
-# lklfuse is installed and included... --install to pull in libs (libfuse3) and
-# --include to place it in /usr/bin path used by the systemd service.
-# loadkeys is run via systemd-vconsole-setup.service. Use true as an alias to
-# avoid unnecessarily needing to install kbd maps.
-# 'file' uses external magic metadata, install it if present.
-"$DRACUT" --install "tail blockdev ps rmdir resize dd vim grep dirname df \
-		   mktemp date file strings id find xfs_io \
-		   strace mkfs mkfs.xfs shuf free su uuidgen losetup ipcmk \
-		   which awk touch cut chmod true false unlink lsusb tee gzip \
-		   ${LKL_SRC}/tools/lkl/lklfuse \
-		   ${req_inst[*]}" \
-	--install-optional /usr/share/file/magic.mgc \
-	--install-optional /usr/share/misc/magic.mgc \
-	--install-optional /usr/share/misc/magic \
-	--include ${LKL_SRC}/tools/lkl/lklfuse /usr/bin/lklfuse \
-	--include "${LKL_SRC}/tools/lkl/systemd/lklfuse-mount@.service" \
-		  "/usr/lib/systemd/system/lklfuse-mount@.service" \
-	--include "${LKL_SRC}/tools/lkl/systemd/61-lklfuse.rules" \
-		  "/usr/lib/udev/rules.d/61-lklfuse.rules" \
-	--include "$pam_su" /etc/pam.d/su \
-	--include "$pam_su" /etc/pam.d/su-l \
-	--include "$pam_other" /etc/pam.d/other \
-	--include "$etc_nsswitch" /etc/nsswitch.conf \
-	--include "${RAPIDO_DIR}/dracut.conf.d/.empty" \
-		  /etc/security/limits.conf \
-	--include "${RAPIDO_DIR}/dracut.conf.d/.empty" /etc/login.defs \
-	--include /usr/bin/true /usr/bin/loadkeys \
-	--add-drivers "fuse usb-storage xhci-hcd xhci-pci" \
-	--modules "base dracut-systemd" \
-	"${DRACUT_RAPIDO_ARGS[@]}" \
-	"$DRACUT_OUT" || _fail "dracut failed"
+cat > $etc_passwd <<EOF
+root:x:0:0:root:/:/bin/bash
+daemon:x:2:2:Daemon:/:/dev/null
+lklfuse:x:2000:2000:lklfuse user:/:/bin/bash
+person:x:2001:2001:user:/:/bin/bash
+lklfusemember:x:2002:2002:lklfusemember user:/:/bin/bash
+EOF
 
-# XXX: dracut strips setuid mode flags, so we append fusermount3 manually.
-# An alternative would be to configure systemd with ProtectSystem=false and
-# manually chmod.
-fum3=$(type -P fusermount3) || _fail
-echo "$fum3" | cpio --create -H newc >> "$DRACUT_OUT" || _fail
+cat > $etc_group <<EOF
+root:x:0:
+disk:x:489:
+lklfuse:x:2000:lklfusemember
+person:x:2001:lklfusemember
+lklfusemember:x:2002:
+EOF
+
+printf -v req_inst_bins 'bin %s\n' "${req_inst[@]}"
+
+cat > $system_init_tgt <<EOF
+[Unit]
+Description=System Initialization
+EOF
+
+PATH="target/release:${PATH}"
+rapido-cut --manifest /dev/stdin <<EOF
+file /rapido-rsc/mem/2048M
+
+include systemd.fest
+
+autorun autorun/lklfuse_udev_usb.sh $*
+
+bin \${LKL_SRC}/tools/lkl/lklfuse
+# path used by systemd service
+slink /usr/bin/lklfuse \${LKL_SRC}/tools/lkl/lklfuse
+
+$req_inst_bins
+bin /usr/lib/systemd/systemd-udevd
+bin awk
+bin blockdev
+bin cat
+bin chmod
+bin cut
+bin date
+bin dd
+bin df
+bin dirname
+bin false
+bin file
+bin find
+bin free
+bin fusermount3
+bin grep
+bin gzip
+bin id
+bin ipcmk
+bin losetup
+bin ls
+bin lsusb
+bin mkfs
+bin mkfs.xfs
+bin mktemp
+bin ps
+bin resize
+bin rm
+bin rmdir
+bin shuf
+bin strace
+bin strings
+bin su
+bin tail
+bin tee
+bin touch
+bin true
+bin udevadm
+bin unlink
+bin uuidgen
+bin vim
+bin which
+bin xfs_io
+# lklfuse invokes /bin/bash, so we at least need a symlink there
+bin /bin/bash
+
+# 'file' uses external magic metadata, install it if present.
+try-bin /usr/share/file/magic.mgc
+try-bin /usr/share/misc/magic.mgc
+try-bin /usr/share/misc/magic
+
+file /usr/lib/systemd/system/modprobe@.service /usr/lib/systemd/system/modprobe@.service
+file /usr/lib/systemd/system/systemd-udevd.service /usr/lib/systemd/system/systemd-udevd.service
+
+# needed for modprobe@.service and other host services
+file /usr/lib/systemd/system/sysinit.target $system_init_tgt
+
+file /usr/lib/systemd/system/lklfuse-mount@.service \${LKL_SRC}/tools/lkl/systemd/lklfuse-mount@.service
+
+# TODO: we should only need a subset of udev rules
+tree /usr/lib/udev/rules.d /usr/lib/udev/rules.d
+# FIXME: if the above tree rules.d recursion finds a host 61-lklfuse.rules then
+# this won't have any effect. Also, we can't put the file before the tree or the
+# tree traversal will skip recursion of the seen parent. TODO: filter this path
+# above and then "unfilter" so that the path can be used?
+file /usr/lib/udev/rules.d/61-lklfuse.rules \${LKL_SRC}/tools/lkl/systemd/61-lklfuse.rules
+
+file /etc/pam.d/su $pam_su
+file /etc/pam.d/su-l $pam_su
+file /etc/pam.d/other $pam_other
+file /etc/nsswitch.conf $etc_nsswitch
+file /etc/passwd $etc_passwd
+file /etc/group $etc_group
+
+# su needs this
+file /etc/security/limits.conf
+
+kmod fuse
+kmod sd_mod
+kmod uas
+kmod usb-storage
+kmod xhci-hcd
+kmod xhci-pci
+EOF

--- a/manifest/systemd.fest
+++ b/manifest/systemd.fest
@@ -1,7 +1,9 @@
+bin journalctl
 bin systemctl
 bin systemd
 bin systemd-journald
 bin systemd-shutdown
+bin systemd-tty-ask-password-agent
 # systemd-executor is required since at least v258
 try-bin systemd-executor
 # for shutdown/reboot via signal
@@ -19,6 +21,8 @@ file /usr/lib/systemd/system/final.target /usr/lib/systemd/system/final.target
 file /usr/lib/systemd/system/poweroff.target /usr/lib/systemd/system/poweroff.target
 file /usr/lib/systemd/system/reboot.target /usr/lib/systemd/system/reboot.target
 file /usr/lib/systemd/system/shutdown.target /usr/lib/systemd/system/shutdown.target
+file /usr/lib/systemd/system/systemd-journald.service /usr/lib/systemd/system/systemd-journald.service
+file /usr/lib/systemd/system/systemd-journald.socket /usr/lib/systemd/system/systemd-journald.socket
 file /usr/lib/systemd/system/systemd-poweroff.service /usr/lib/systemd/system/systemd-poweroff.service
 file /usr/lib/systemd/system/systemd-reboot.service /usr/lib/systemd/system/systemd-reboot.service
 file /usr/lib/systemd/system/umount.target /usr/lib/systemd/system/umount.target
@@ -28,3 +32,5 @@ file /usr/lib/systemd/system/rapido-autorun.service systemd/rapido-autorun.servi
 file /usr/lib/systemd/system/rapido-init.target systemd/rapido-init.target
 slink /usr/lib/systemd/system/default.target rapido-init.target
 slink /usr/lib/systemd/system/rapido-init.target.wants/rapido-autorun.service ../rapido-autorun.service
+# no ordering requirement for journald for now; may start during/after autorun.
+slink /usr/lib/systemd/system/rapido-init.target.wants/systemd-journald.service ../systemd-journald.service

--- a/readme.md
+++ b/readme.md
@@ -8,9 +8,6 @@ cargo build --offline --release
 ./rapido cut simple-example # boot a throwaway VM using the host kernel
 ```
 
-A demonstration screencast can be found
-[here](https://github.com/rapido-linux/rapido/raw/master/docs/demo.svg).
-
 
 ## Setup
 
@@ -23,9 +20,9 @@ Clone this repository and install the following dependencies:
 * [iproute2](https://wiki.linuxfoundation.org/networking/iproute2):
   * Configures Bridge and TAP devices on the host (optional)
 
-Rapido obtains all dependencies from the local system; no magic images
+Rapido obtains **all** dependencies from the local system; no magic images
 or internet downloads are necessary. Individual cut scripts (e.g.
-`cut/fstests_btrfs.sh`) may require extra dependencies.
+`cut/fstests_btrfs.sh`) may require extra local dependencies.
 
 Rapido is primarily configured via `rapido.conf`. To boot a custom Linux
 kernel, copy [rapido.conf.example](rapido.conf.example) and set the
@@ -54,6 +51,12 @@ choose a `cut` script to generate a VM image. E.g.
 
 The cut script collects all required kernel modules and user-space dependencies
 from the local system and writes a VM initramfs image to `initrds/myinitrd`.
+
+Rapido attempts to use the `copy_file_range()` syscall when copying file data
+to 4K-aligned initramfs destination offsets. This allows the host filesystem
+to avoid file data duplication by using reflinks where supported, e.g. on XFS
+and Btrfs.
+
 Once generated, a VM using the image and kernel will boot immediately.
 Subsequent VMs can be booted manually via:
 ```shell

--- a/src/bin/rapido-cut.rs
+++ b/src/bin/rapido-cut.rs
@@ -888,29 +888,32 @@ struct ArgsState {
 }
 
 // loosely based on the Linux kernel's gen_init_cpio format
-const MANIFEST_FORMAT: &str = "\nManifest format:\n\
-    # a comment\n\
-    bin ELF\n\
-    try-bin ELF\n\
-    kmod MODULE\n\
-    try-kmod MODULE\n\
-    dir NAME\n\
-    file NAME LOCATION\n\
-    autorun LOCATION [LOCATION ...]\n\
-    tree NAME LOCATION\n\
-    slink NAME TARGET\n\
-    filter FILTER\n\
-    include MANIFEST\n\
-    \n\
-    ELF:      ELF executable, archived with all needed dependencies.\n\
-              Directory paths are traversed, with child paths handled as ELFs.\n\
-    MODULE:   kernel module, archived with dependencies\n\
-    NAME:     name of the file or directory in the archive\n\
-    LOCATION: local path to obtain data, user, group, mode etc. for this item\n\
-    FILTER:   Archive path to treat as already processed. Directory traversals\n\
-              will not go beneath this path.\n\
-    MANIFEST: file containing entries described above\n";
+const MANIFEST_FORMAT: &str = r#"
+Manifest format:
 
+# a comment
+bin ELF
+try-bin ELF
+kmod MODULE
+try-kmod MODULE
+dir NAME
+file NAME [LOCATION]
+autorun LOCATION [LOCATION ...]
+tree NAME LOCATION
+slink NAME TARGET
+filter FILTER
+include MANIFEST
+
+ELF:      ELF executable, archived with all needed dependencies.
+          Directory paths are traversed, with child paths handled as ELFs.
+MODULE:   Kernel module, archived with dependencies
+NAME:     Name of the file or directory in the archive
+LOCATION: Local path to obtain data, user, group, mode etc. for this item
+FILTER:   Archive path to treat as already processed. Directory traversals
+          will not go beneath this path.
+MANIFEST: File containing entries described above. Entries are processed in
+          order.
+"#;
 
 fn args_usage(params: &[Argument]) {
     argument::print_help("rapido-cut", "", params);

--- a/systemd/simple-example.service
+++ b/systemd/simple-example.service
@@ -2,6 +2,7 @@
 Description=Rapido Systemd Flag File
 DefaultDependencies=no
 Before=rapido-autorun.service
+After=systemd-journald.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
```
The following changes since commit f72b5fda91bb84b14e27b603a9f8c3c6754151b6:

  rapido: add "cargo build" suggestion if cut returns ENOENT (2026-04-22 15:59:03 +1000)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git lklfuse_rapido_cut_convert

for you to fetch changes up to 8ea6cd126e30e7a2d072bb466905172fb0101600:

  lklfuse_udev_usb: convert to use rapido-cut instead of dracut (2026-04-23 23:17:12 +1000)

----------------------------------------------------------------
David Disseldorp (4):
      readme: document reflink optimization
      rapido-cut: use raw string literal syntax for usage text
      manifest/systemd: add journald
      lklfuse_udev_usb: convert to use rapido-cut instead of dracut

 autorun/lklfuse_udev_usb.sh    |  24 +-----
 cut/lklfuse_udev_usb.sh        | 165 +++++++++++++++++++++++++++++++----------
 manifest/systemd.fest          |   6 ++
 readme.md                      |  13 ++--
 src/bin/rapido-cut.rs          |  49 ++++++------
 systemd/simple-example.service |   1 +
 6 files changed, 166 insertions(+), 92 deletions(-)
```