### PR TITLE
ksmbd_btrfs: convert to use rapido-cut

### DIFF
--- a/autorun/ksmbd_btrfs.sh
+++ b/autorun/ksmbd_btrfs.sh
@@ -9,15 +9,6 @@ modprobe zram num_devices="1" || _fatal "failed to load zram module"
 modprobe ksmbd
 _vm_ar_dyn_debug_enable
 
-# ksmbd utilities are currently all symlinks to ksmbd.tools
-for i in ksmbd.addshare ksmbd.adduser ksmbd.control ksmbd.mountd; do
-	p="${PATH}:/usr/libexec:/sbin:/usr/sbin"
-        if [ -n "$KSMBD_TOOLS_SRC" ]; then
-		p="${KSMBD_TOOLS_SRC}/tools"
-        fi
-	ln -s $(PATH=$p type -P ksmbd.tools) /sbin/${i}
-done
-
 # use a non-configurable UID/GID for now
 cifs_xid="579120"
 echo "${CIFS_USER}:x:${cifs_xid}:${cifs_xid}:Samba user:/:/sbin/nologin" \
@@ -29,7 +20,6 @@ echo "${FSTESTS_ZRAM_SIZE:-1G}" > /sys/block/zram0/disksize \
 mkfs.btrfs /dev/zram0 || _fatal "mkfs failed"
 # ksmbd-tools may be built with a default prefix "/usr/local" or "/". There's
 # no easy way to find out, so account for both paths.
-mkdir -p /mnt /etc/ksmbd /usr/local/etc/ksmbd /usr/local/var/run
 mount -t btrfs /dev/zram0 /mnt || _fatal
 chmod 777 /mnt || _fatal
 

--- a/cut/ksmbd_btrfs.sh
+++ b/cut/ksmbd_btrfs.sh
@@ -5,12 +5,11 @@
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-req_inst=()
-_rt_require_ksmbd_tools req_inst
+ksmbd_tools_bin=()
+_rt_require_ksmbd_tools ksmbd_tools_bin
 _rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
 	|| _fail "failed to calculate memory resources"
 _rt_require_conf_setting CIFS_USER CIFS_PW CIFS_SHARE
-printf -v req_inst_bins 'bin %s\n' "${req_inst[@]}"
 
 PATH="target/release:${PATH}"
 rapido-cut --manifest /dev/stdin <<EOF
@@ -19,7 +18,6 @@ include net.fest
 
 autorun autorun/ksmbd_btrfs.sh $*
 
-$req_inst_bins
 bin awk
 bin cat
 bin chmod
@@ -62,6 +60,17 @@ bin touch
 bin true
 bin uniq
 bin which
+# ksmbd utilities are currently all symlinks to ksmbd.tools
+bin ${ksmbd_tools_bin[0]}
+slink /usr/bin/ksmbd.addshare ${ksmbd_tools_bin[0]}
+slink /usr/bin/ksmbd.adduser ${ksmbd_tools_bin[0]}
+slink /usr/bin/ksmbd.control ${ksmbd_tools_bin[0]}
+slink /usr/bin/ksmbd.mountd ${ksmbd_tools_bin[0]}
+
+dir /etc/ksmbd
+dir /mnt
+dir /usr/local/etc/ksmbd
+dir /usr/local/var/run
 
 kmod aes
 kmod btrfs

--- a/cut/ksmbd_btrfs.sh
+++ b/cut/ksmbd_btrfs.sh
@@ -1,28 +1,81 @@
 #!/bin/bash
 # SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
-# Copyright (C) SUSE LLC 2023, all rights reserved.
+# Copyright (C) SUSE S.A. 2023-2026, all rights reserved.
 
 RAPIDO_DIR="$(realpath -e ${0%/*})/.."
 . "${RAPIDO_DIR}/runtime.vars"
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/ksmbd_btrfs.sh" "$@"
-_rt_require_networking
 req_inst=()
 _rt_require_ksmbd_tools req_inst
 _rt_human_size_in_b "${FSTESTS_ZRAM_SIZE:-1G}" zram_bytes \
 	|| _fail "failed to calculate memory resources"
-_rt_mem_resources_set "$((1024 + (zram_bytes / 1048576)))M"
 _rt_require_conf_setting CIFS_USER CIFS_PW CIFS_SHARE
+printf -v req_inst_bins 'bin %s\n' "${req_inst[@]}"
 
-"$DRACUT" --install "tail ps rmdir resize dd grep find df sha256sum \
-		   strace mkfs mkfs.btrfs awk dirname \
-		   stat which touch cut chmod true false \
-		   getfattr setfattr getfacl setfacl killall sync \
-		   id sort uniq date expr tac diff head dirname seq \
-		   ${req_inst[*]}" \
-	--add-drivers "btrfs zram lzo lzo-rle \
-		       ksmbd ecb hmac md5 aes cmac sha256 sha512 ccm \
-		       gcm crc32" \
-	--modules "base" \
-	"${DRACUT_RAPIDO_ARGS[@]}" \
-	"$DRACUT_OUT" || _fail "dracut failed"
+PATH="target/release:${PATH}"
+rapido-cut --manifest /dev/stdin <<EOF
+file /rapido-rsc/mem/$((1024 + (zram_bytes / 1048576)))M
+include net.fest
+
+autorun autorun/ksmbd_btrfs.sh $*
+
+$req_inst_bins
+bin awk
+bin cat
+bin chmod
+bin cut
+bin date
+bin dd
+bin df
+bin diff
+bin dirname
+bin dirname
+bin expr
+bin false
+bin find
+bin getfacl
+bin getfattr
+bin grep
+bin head
+bin id
+bin killall
+bin ln
+bin ls
+bin mkdir
+bin mkfs
+bin mkfs.btrfs
+bin ps
+bin resize
+bin rmdir
+bin seq
+bin setfacl
+bin setfattr
+bin sha256sum
+bin sleep
+bin sort
+bin stat
+bin strace
+bin sync
+bin tac
+bin tail
+bin touch
+bin true
+bin uniq
+bin which
+
+kmod aes
+kmod btrfs
+kmod ccm
+kmod cmac
+kmod crc32
+kmod ecb
+kmod gcm
+kmod hmac
+kmod ksmbd
+kmod lzo
+kmod lzo-rle
+kmod md5
+kmod sha256
+kmod sha512
+kmod zram
+EOF


### PR DESCRIPTION
```
The following changes since commit 8ea6cd126e30e7a2d072bb466905172fb0101600:

  lklfuse_udev_usb: convert to use rapido-cut instead of dracut (2026-04-23 23:17:12 +1000)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git ksmbd_use_rapido_cut

for you to fetch changes up to 86fa005ff934497eff7b33270869f40d8d009657:

  ksmbd_btrfs: replace ln and mkdir calls with cpio entries (2026-04-29 14:31:34 +1000)

----------------------------------------------------------------
David Disseldorp (2):
      cut/ksmbd_btrfs: use rapido-cut instead of dracut
      ksmbd_btrfs: replace ln and mkdir calls with cpio entries

 autorun/ksmbd_btrfs.sh | 10 ------
 cut/ksmbd_btrfs.sh     | 98 ++++++++++++++++++++++++++++++++++++++++----------
 2 files changed, 80 insertions(+), 28 deletions(-)
```