### PR TITLE
load sd_mod for lklfuse and dump ci host storage info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends --no-install-suggests \
             cargo-1.85 rustc "$QEMU_SYSTEM" qemu-utils expect \
             make flex bison libelf-dev
+          sudo lsblk
+          df
       - name: cargo test
         run: |
           cargo-1.85 test --offline --lib --bins

--- a/autorun/lklfuse_udev_usb.sh
+++ b/autorun/lklfuse_udev_usb.sh
@@ -12,7 +12,7 @@ _vm_ar_hosts_create
 # After/Requires=modprobe@fuse.service for /dev/fuse presence, except the mode
 # is only changed to 0666 by a 50-udev-default.rules fuse rule, which may be
 # processed *after* lklfuse-mount@.service proceeds.
-modprobe -a usb-storage xhci-hcd xhci-pci fuse
+modprobe -a usb-storage xhci-hcd xhci-pci fuse sd_mod
 _vm_ar_dyn_debug_enable
 
 # fuse by default won't allow access to non-mounters, we need to set:


### PR DESCRIPTION
```
The following changes since commit 5a10ffdf383a28031ee69266381c9548745993d3:

  cut: dracut install stty instead of resize (2026-05-07 22:22:40 +1000)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git sd_mod_and_ci_info

for you to fetch changes up to 76e21da1e4baf093978194c724b8cdea36abe818:

  autorun/lklfuse_udev_usb: modprobe sd_mod (2026-05-08 14:14:34 +1000)

----------------------------------------------------------------
David Disseldorp (2):
      ci: dump lsblk and df info for host
      autorun/lklfuse_udev_usb: modprobe sd_mod

 .github/workflows/ci.yml    | 2 ++
 autorun/lklfuse_udev_usb.sh | 2 +-
 2 files changed, 3 insertions(+), 1 deletion(-)
```