### PR TITLE
ci: switch from ubuntu-latest to ubuntu-slim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ on:
 # if building distro config install: libdw-dev libssl-dev
 jobs:
   test:
-    # aarch64 github runners don't provide kvm
-    runs-on: ubuntu-latest
+    # aarch64 github runners don't provide kvm. ubuntu-latest can be used if
+    # more memory + CPU resources are needed.
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
       - name: install rust and kernel build tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
       - name: build and setup rapido net
         # $USER is set on ubuntu-latest but missing on ubuntu-slim
         run: |
+          sudo chmod 0666 /dev/kvm
+          sudo chmod 0644 /boot/vmlinuz-*
           export USER=$(id -un)
           cargo-1.85 build --offline --release
           cp -r net-conf.example/ net-conf
           sudo EDITOR=cat ./rapido setup-network -o $USER -b rapido-br -a "192.168.155.10/24"
-          sudo chmod 0644 /boot/vmlinuz-*
-          sudo chmod 0666 /dev/kvm
       - name: boot host kernel VM
         run: |
          ./rapido cut -B -x "ping -c3 192.168.155.10 && echo test passed; exit" simple-network

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
           cargo-1.85 test --offline --lib --bins
           popd
       - name: build and setup rapido net
+        # $USER is set on ubuntu-latest but missing on ubuntu-slim
         run: |
+          export USER=$(id -un)
           cargo-1.85 build --offline --release
           cp -r net-conf.example/ net-conf
           sudo EDITOR=cat ./rapido setup-network -o $USER -b rapido-br -a "192.168.155.10/24"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends --no-install-suggests \
             cargo-1.85 rustc qemu-system-x86 qemu-utils expect \
-            make flex bison libelf-dev
+            make flex bison libelf-dev cpio
           sudo lsblk
           df
       - name: cargo test


### PR DESCRIPTION
The ubuntu-latest runner provides 16GB RAM, which we don't need given that we're no longer running xfstests.