### PR TITLE
iSCSI changes

### DIFF
--- a/autorun/libiscsi_test_tool.sh
+++ b/autorun/libiscsi_test_tool.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE S.A. 2026, all rights reserved.
+
+_vm_ar_env_check || exit 1
+_vm_ar_dyn_debug_enable
+
+set -x
+ip addr
+PATH="${LIBISCSI_SRC}/test-tool:${PATH}"
+set +x
+
+chaps=""
+[[ -n "${ISCSI_USER}${ISCSI_PASS}" ]] && chaps="${ISCSI_USER}%${ISCSI_PASS}@"
+
+cat <<EOF
+Ready for iSCSI testing. E.g.
+iscsi-test-cu iscsi://${chaps}${INITIATOR_DISCOVERY_ADDR}:3260/${TARGET_IQN}/0
+
+Have a lot of fun...
+EOF

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -137,7 +137,7 @@ for tpgt in tpgt_1 tpgt_2; do
 	echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/default_erl
 	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/demo_mode_discovery
 	echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/prod_mode_write_protect
-	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/demo_mode_write_protect
+	echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/demo_mode_write_protect
 	echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/cache_dynamic_acls
 	echo 64 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/default_cmdsn_depth
 	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/generate_node_acls

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -143,8 +143,21 @@ for tpgt in tpgt_1 tpgt_2; do
 	echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/generate_node_acls
 	echo 2 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/netif_timeout
 	echo 15 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/login_timeout
-	# disable auth
-	echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/authentication
+
+	#### authentication for iSCSI Target Portal Group
+	if [[ -n "${ISCSI_USER}${ISCSI_PASS}" ]]; then
+		echo 1 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/authentication
+		echo -n "$ISCSI_USER" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/auth/userid
+		echo -n "$ISCSI_PASS" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/auth/password
+	else
+		# disable auth
+		echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/attrib/authentication
+	fi
+
+	if [[ -n "${ISCSI_MUTUAL_USER}${ISCSI_MUTUAL_PASS}" ]]; then
+		echo -n "$ISCSI_MUTUAL_USER" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/auth/userid_mutual
+		echo -n "$ISCSI_MUTUAL_PASS" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/auth/password_mutual
+	fi
 
 	#### authentication for iSCSI Target Portal Group
 	#### Parameters for iSCSI Target Portal Group
@@ -180,7 +193,16 @@ for tpgt in tpgt_1 tpgt_2; do
 		mkdir -p /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}
 		[ $? -eq 0 ] || _fatal
 		echo 64 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}/cmdsn_depth
-		#### iSCSI Initiator ACL authentication information
+		#### per-Initiator ACL auth needs explicit config. It's not inherited from parent TPG
+		if [[ -n "${ISCSI_USER}${ISCSI_PASS}" ]]; then
+			echo -n "$ISCSI_USER" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}/auth/userid
+			echo -n "$ISCSI_PASS" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}/auth/password
+		fi
+		if [[ -n "${ISCSI_MUTUAL_USER}${ISCSI_MUTUAL_PASS}" ]]; then
+			echo -n "$ISCSI_MUTUAL_USER" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}/auth/userid_mutual
+			echo -n "$ISCSI_MUTUAL_PASS" > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}/auth/password_mutual
+		fi
+
 		#### iSCSI Initiator ACL TPG attributes
 		echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}/attrib/random_r2t_offsets
 		echo 0 > /sys/kernel/config/target/iscsi/${TARGET_IQN}/${tpgt}/acls/${initiator}/attrib/random_datain_seq_offsets

--- a/autorun/lio_local.sh
+++ b/autorun/lio_local.sh
@@ -24,10 +24,7 @@ udevadm settle || _fatal
 
 _vm_ar_configfs_mount
 
-modprobe target_core_mod || _fatal
-modprobe target_core_iblock || _fatal
-modprobe target_core_file || _fatal
-modprobe iscsi_target_mod || _fatal
+modprobe -a loop target_core_iblock target_core_file iscsi_target_mod || _fatal
 
 _vm_ar_dyn_debug_enable
 

--- a/autorun/openiscsi.sh
+++ b/autorun/openiscsi.sh
@@ -20,7 +20,7 @@ modprobe iscsi_tcp
 
 _vm_ar_dyn_debug_enable
 
-mkdir -p /etc/iscsi
+mkdir -p /etc/iscsi /run/lock/
 [ -n "$INITIATOR_IQNS" ] \
 	|| _fatal "INITIATOR_IQNS config required for InitiatorName"
 inames=( $INITIATOR_IQNS )

--- a/autorun/openiscsi.sh
+++ b/autorun/openiscsi.sh
@@ -34,6 +34,21 @@ iscsid || _fatal
 [ -n "$INITIATOR_DISCOVERY_ADDR" ] \
 	|| _fatal "INITIATOR_DISCOVERY_ADDR config required for SendTargets"
 iscsiadm -m discovery -t sendtargets -p $INITIATOR_DISCOVERY_ADDR || _fatal
+
+# auth for normal (non-discovery) sessions
+for i in $(ls /etc/iscsi/nodes/*/*/default); do
+	if [[ -n "${ISCSI_USER}${ISCSI_PASS}" ]]; then
+		sed -i "s#node.session.auth.authmethod = .*#node.session.auth.authmethod = CHAP#" $i
+		echo "node.session.auth.username = $ISCSI_USER" >> $i
+		echo "node.session.auth.password = $ISCSI_PASS" >> $i
+	fi
+
+	if [[ -n "${ISCSI_MUTUAL_USER}${ISCSI_MUTUAL_PASS}" ]]; then
+		echo "node.session.auth.username_in = $ISCSI_MUTUAL_USER" >> $i
+		echo "node.session.auth.password_in = $ISCSI_MUTUAL_PASS" >> $i
+	fi
+done
+
 # login to all discovered targets
 iscsiadm -m node -l all || _fatal
 set +x

--- a/cut/libiscsi_test_tool.sh
+++ b/cut/libiscsi_test_tool.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE S.A. 2026, all rights reserved.
+PATH="target/release:${PATH}"
+rapido-cut --manifest /dev/stdin <<EOF
+file /rapido-rsc/mem/512M
+include net.fest
+
+autorun autorun/libiscsi_test_tool.sh $*
+
+bin \${LIBISCSI_SRC}/test-tool/iscsi-test-cu
+bin cat
+bin find
+bin grep
+bin hostname
+bin ls
+bin nc
+bin ps
+EOF

--- a/cut/lio_local.sh
+++ b/cut/lio_local.sh
@@ -1,29 +1,42 @@
 #!/bin/bash
-#
-# Copyright (C) SUSE LINUX GmbH 2016, all rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published
-# by the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) version 3.
-#
-# This library is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-# License for more details.
+# SPDX-License-Identifier: (LGPL-2.1 OR LGPL-3.0)
+# Copyright (C) SUSE S.A. 2016-2026, all rights reserved.
+PATH="target/release:${PATH}"
+rapido-cut --manifest /dev/stdin <<EOF
+file /rapido-rsc/mem/2048M
 
-RAPIDO_DIR="$(realpath -e ${0%/*})/.."
-. "${RAPIDO_DIR}/runtime.vars"
+include net.fest
 
-_rt_require_dracut_args "$RAPIDO_DIR/autorun/lio_local.sh" "$@"
-_rt_require_networking
-_rt_mem_resources_set "2048M"
+autorun autorun/lio_local.sh $*
 
-"$DRACUT" --install "tail blockdev ps rmdir stty dd vim grep find df sha256sum \
-		   strace mkfs.xfs truncate losetup dmsetup \
-		   /usr/lib/udev/rules.d/95-dm-notify.rules" \
-	--add-drivers "iscsi_target_mod target_core_mod target_core_iblock \
-		       target_core_file dm-delay loop" \
-	--modules "base" \
-	"${DRACUT_RAPIDO_ARGS[@]}" \
-	"$DRACUT_OUT" || _fail "dracut failed"
+bin blockdev
+bin cat
+bin dd
+bin df
+bin dmsetup
+bin find
+bin grep
+bin hostname
+bin ln
+bin losetup
+bin ls
+bin mkdir
+bin mkfs.xfs
+bin nc
+bin ps
+bin rmdir
+bin sha256sum
+bin sleep
+bin strace
+bin stty
+bin tail
+bin truncate
+
+file /usr/lib/udev/rules.d/95-dm-notify.rules /usr/lib/udev/rules.d/95-dm-notify.rules
+
+kmod iscsi_target_mod
+kmod target_core_iblock
+kmod target_core_file
+kmod dm-delay
+kmod loop
+EOF

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -324,6 +324,12 @@ INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 #INITIATOR_DISCOVERY_ADDR=""
 ################################
 
+########## libiscsi_test_tool.sh ###########
+# Path to a build of the libiscsi source available at
+# https://github.com/sahlberg/libiscsi .
+#LIBISCSI_SRC=
+############################################
+
 ########## cut/ltp.sh ##########
 # LTP_DIR should correspond to the ltp directory tree after make install.
 # The default below matches ltp's default install path prefix.

--- a/rapido.conf.example
+++ b/rapido.conf.example
@@ -134,6 +134,16 @@ TARGET_IQN="iqn.2003-01.org.linux-iscsi:rapido"
 # correspond to the libiscsi test utility.
 INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test \
 		iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test-2"
+
+# optional CHAP username and password
+# e.g. ISCSI_USER="chapuser"
+#ISCSI_USER=""
+# e.g. ISCSI_PASS="chappass"
+#ISCSI_PASS=""
+# e.g. ISCSI_MUTUAL_USER="mutualuser"
+#ISCSI_MUTUAL_USER=""
+# e.g. ISCSI_MUTUAL_PASS="mutualpass"
+#ISCSI_MUTUAL_PASS=""
 ###########################
 
 ####### autorun/fstests_*.sh #######


### PR DESCRIPTION
```
The following changes since commit 77c5672c6267e06f056fa22cb7286c6f7c5fef4b:

  readme: link to ci.yml as kernel-CI-on-GitHub example (2026-05-19 12:08:01 +1000)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git lio_and_libiscsi

for you to fetch changes up to 84545807b44dd7ee8e2e1371e0a2049752b1d2bf:

  libiscsi_test_tool: cut and autorun scripts (2026-05-22 21:56:15 +1000)

----------------------------------------------------------------
David Disseldorp (6):
      autorun/lio_local: preload the loop kernel module
      cut/lio_local: convert from dracut to rapido-cut
      autorun: add CHAP support to lio-local and openiscsi images
      autorun/lio_local: disable demo_mode_write_protect
      autorun/openiscsi: create /run/lock/
      libiscsi_test_tool: cut and autorun scripts

 autorun/libiscsi_test_tool.sh | 21 +++++++++++++++++++++
 autorun/lio_local.sh          | 35 +++++++++++++++++++++++++++--------
 autorun/openiscsi.sh          | 17 ++++++++++++++++-
 cut/libiscsi_test_tool.sh     | 19 +++++++++++++++++++
 cut/lio_local.sh              | 63 ++++++++++++++++++++++++++++++++++++++-------------------------
 rapido.conf.example           | 16 ++++++++++++++++
 6 files changed, 137 insertions(+), 34 deletions(-)
 create mode 100755 autorun/libiscsi_test_tool.sh
 create mode 100755 cut/libiscsi_test_tool.sh
```