### PR TITLE
ci: drop explicit rust v1.85 installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ name: CI
 on:
   pull_request:
 
-# "cargo" default package results in v1.75, which doesn't support v4 lock files
-# "cargo test uses lib and bins only, as doc test breaks for some reason
+# "cargo" default package results in v1.95
 # chmod vmlinuz-`uname -r` as it's 0600 by default
 # chmod /dev/kvm to allow non-root QEMU to use it
 # if building distro config install: libdw-dev libssl-dev
@@ -33,22 +32,21 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends --no-install-suggests \
-            cargo-1.85 rustc qemu-system-x86 qemu-utils expect \
-            make flex bison libelf-dev
+            qemu-system-x86 qemu-utils expect make flex bison libelf-dev
           sudo lsblk
           df
       - name: cargo test
         run: |
-          cargo-1.85 test --offline --lib --bins
+          cargo --offline test
           pushd src/cpio
-          cargo-1.85 test --offline --lib --bins
+          cargo --offline test
           popd
           pushd src/kv-conf/
-          cargo-1.85 test --offline --lib --bins
+          cargo --offline test
           popd
       - name: build and setup rapido net
         run: |
-          cargo-1.85 build --offline --release
+          cargo --offline build --release
           cp -r net-conf.example/ net-conf
           sudo EDITOR=cat ./rapido setup-network -o $USER -b rapido-br -a "192.168.155.10/24"
           sudo chmod 0644 /boot/vmlinuz-*


### PR DESCRIPTION
The ubuntu-latest runner has moved its default from v1.75 to v1.95, so we no longer need to explicitly install a more recent version for v4 lock file support.