### PR TITLE
Minor changes

### DIFF
--- a/cut/lio_local.sh
+++ b/cut/lio_local.sh
@@ -13,6 +13,7 @@ bin blockdev
 bin cat
 bin dd
 bin df
+bin dmesg
 bin dmsetup
 bin find
 bin grep

--- a/src/bin/rapido-vm.rs
+++ b/src/bin/rapido-vm.rs
@@ -417,11 +417,17 @@ fn vm_start(
         qemu_args.params.extend(qea.split(&[' ', '\n']));
     }
 
-    let mut spawned_vm = process::Command::new(qemu_args.qemu_bin)
+    let mut spawned_vm = match process::Command::new(qemu_args.qemu_bin)
         .args(qemu_args.params)
         .args(net_params_stash)
         .spawn()
-        .expect("failed to execute qemu");
+    {
+        Err(e) => {
+            eprintln!("{} failed: {:?}", qemu_args.qemu_bin, e);
+            return Err(e);
+        }
+        Ok(s) => s,
+    };
     match spawned_vm.wait() {
         Err(e) => {
             // TODO stdout / stderr lost here?

--- a/src/bin/rapido-vm.rs
+++ b/src/bin/rapido-vm.rs
@@ -153,11 +153,10 @@ struct QemuArgs<'a> {
     params: Vec<&'a str>,
 }
 
-fn vm_qemu_args_get(conf: &HashMap<String, String>) -> io::Result<QemuArgs> {
+fn vm_qemu_args_get(conf: &HashMap<String, String>) -> io::Result<QemuArgs<'_>> {
     let mut params = vec![];
     let mut qemu_args: Option<QemuArgs> = None;
 
-    //let (kconfig: String, krel: Option<&str>) = match conf.get("KERNEL_SRC") {
     let (kconfig, krel) = match conf.get("KERNEL_SRC") {
         Some(ks) if !ks.is_empty() => (format!("{ks}/.config"), None),
         None | Some(_) => match conf.get("KERNEL_RELEASE") {


### PR DESCRIPTION
```
The following changes since commit 4ae962faeb141c9bb3011d73df32c70318b48131:

  ci: drop explicit rust v1.85 installation (2026-06-09 17:53:07 +1000)

are available in the Git repository at:

  https://github.com/ddiss/rapido.git minor_changes

for you to fetch changes up to 860d8739f2491e40f3f9f9fcefe37e4f67abf3d4:

  rapido-vm: add explicit lifetime syntax (2026-06-26 19:02:45 +1000)

----------------------------------------------------------------
David Disseldorp (3):
      cut/lio-local: add dmesg
      rapido-vm: don't panic if qemu is missing
      rapido-vm: add explicit lifetime syntax

 cut/lio_local.sh     |  1 +
 src/bin/rapido-vm.rs | 14 +++++++++-----
 2 files changed, 10 insertions(+), 5 deletions(-)
```